### PR TITLE
Fixed serverless-python-requirements plugin slim package default pattern

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -203,11 +203,14 @@ custom:
     packRequirements: false
   scripts:
     hooks:
-      # Run db migration as part of the deployment process
       'deploy:finalize': SLS_DEBUG=true sls invoke -f migrate --STAGE ${opt:STAGE} --noinput
   pythonRequirements:
      zip: true
      slim: true
+     slimPatternsAppendDefaults: false
+     slimPatterns:
+       - '**/*.py[c|o]'
+       - '**/__pycache__*'
   customDomain:
     domainName: ${env:API_DOMAIN_NAME}
     basePath: ''


### PR DESCRIPTION
* Default slim package pattern include stripping dist-info
  which is vital for setuptools pkg_resources.get_distribution()
  use case such as in google-api-python-client library service discovery.
  Fix: disable and overwrite default pattern without stripping dist-info.
  https://github.com/UnitedIncome/serverless-python-requirements#slim-package
  https://github.com/serverless/serverless/issues/5333