### PR TITLE
Updated get completed workflows by batch run query

### DIFF
--- a/data_portal/models.py
+++ b/data_portal/models.py
@@ -337,8 +337,6 @@ class WorkflowManager(models.Manager):
         qs: QuerySet = self.filter(
             batch_run=batch_run,
             start__isnull=False,
-            end__isnull=False,
-            end_status__isnull=False,
         ).exclude(end_status__icontains=WorkflowStatus.RUNNING.value)
         return qs
 


### PR DESCRIPTION
* Remove `end` time is not null filter condition as
  `timeStopped` can be NULL when WES engine crash!
* Remove redundant `end_status` is not null check
