### PR TITLE
Updated orchestrator to skip NTC sample

### DIFF
--- a/data_processors/pipeline/tests/test_orchestrator.py
+++ b/data_processors/pipeline/tests/test_orchestrator.py
@@ -90,6 +90,8 @@ class OrchestratorUnitTests(PipelineUnitTestCase):
             "MDX199999_L1999999_topup_S2_R2_001.fastq.gz",
             "L9111111_topup_S3_R1_001.fastq.gz",
             "L9111111_topup_S3_R2_001.fastq.gz",
+            "NTC_L111111_S4_R1_001.fastq.gz",
+            "NTC_L111111_S4_R2_001.fastq.gz",
         ]
         mock_file_list.items = []
         for mock_file in mock_files:


### PR DESCRIPTION
* Added note about germline single `fastq-directory` and `fastq_list.csv`
* Improved logic: if job list is empty reset running state
* Improved logic: if existing batch run on going, return proper message

Fixed #138
