### PR TITLE
Fixed buildspec exclude serverless cli check

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,7 +18,6 @@ phases:
       - which docker
       - which docker-compose
       - which python3
-      - which serverless
       - docker-compose up -d
       - make load_localstack
       - python3 manage.py test


### PR DESCRIPTION
* We now use local locked sls version through npx
