### PR TITLE
Reports API

### DIFF
--- a/data_portal/serializers.py
+++ b/data_portal/serializers.py
@@ -193,21 +193,12 @@ class RunIdSerializer(serializers.BaseSerializer):
     def create(self, validated_data):
         raise NotImplementedError(READ_ONLY_SERIALIZER)
 
-class ReportIdSerializer(serializers.BaseSerializer):
-#    def to_representation(self, instance):
-#        return instance.id
-    
-    def to_representation(self, instance):
-        return instance.id
 
-    def to_internal_value(self, data):
-        raise NotImplementedError(READ_ONLY_SERIALIZER)
+class ReportSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Report
+        fields = '__all__'
 
-    def update(self, instance, validated_data):
-        raise NotImplementedError(READ_ONLY_SERIALIZER)
-
-    def create(self, validated_data):
-        raise NotImplementedError(READ_ONLY_SERIALIZER)
 
 class BucketIdSerializer(serializers.BaseSerializer):
     def to_representation(self, instance):

--- a/data_portal/serializers.py
+++ b/data_portal/serializers.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 from rest_framework import serializers
 from rest_framework.fields import empty
 
-from data_portal.models import S3Object, LIMSRow, GDSFile
+from data_portal.models import S3Object, LIMSRow, GDSFile, Report
 
 READ_ONLY_SERIALIZER = 'READ ONLY SERIALIZER'
 
@@ -194,8 +194,11 @@ class RunIdSerializer(serializers.BaseSerializer):
         raise NotImplementedError(READ_ONLY_SERIALIZER)
 
 class ReportIdSerializer(serializers.BaseSerializer):
+#    def to_representation(self, instance):
+#        return instance.id
+    
     def to_representation(self, instance):
-        return instance.sample_id
+        return instance.id
 
     def to_internal_value(self, data):
         raise NotImplementedError(READ_ONLY_SERIALIZER)

--- a/data_portal/urls.py
+++ b/data_portal/urls.py
@@ -29,6 +29,9 @@ runs_router.register(r'gds', RunDataGDSFileViewSet, basename='run-gds')
 
 reports_router = routers.NestedDefaultRouter(router, r'reports', lookup='report')
 reports_router.register(r'subject', ReportSubjectViewSet, basename='report-subject')
+reports_router.register(r'sample', ReportSubjectViewSet, basename='report-subject')
+reports_router.register(r'library', ReportSubjectViewSet, basename='report-subject')
+reports_router.register(r'type', ReportSubjectViewSet, basename='report-subject')
 
 urlpatterns = [
     path('files', views.search_file, name='file-search'),
@@ -37,6 +40,7 @@ urlpatterns = [
     path('', include(router.urls)),
     path('', include(subjects_router.urls)),
     path('', include(runs_router.urls)),
+    path('', include(reports_router.urls))
 ]
 
 handler500 = 'rest_framework.exceptions.server_error'

--- a/data_portal/urls.py
+++ b/data_portal/urls.py
@@ -4,7 +4,7 @@ from rest_framework_nested import routers
 from data_portal import views
 from .viewsets import LIMSRowViewSet, S3ObjectViewSet, BucketViewSet, SubjectViewSet, SubjectS3ObjectViewSet, \
     RunViewSet, PresignedUrlViewSet, RunDataLIMSViewSet, RunDataS3ObjectViewSet, SubjectGDSFileViewSet, \
-    RunDataGDSFileViewSet, GDSFileViewSet, ReportViewSet, ReportSubjectViewSet
+    RunDataGDSFileViewSet, GDSFileViewSet, ReportViewSet
 from .routers import OptionalSlashDefaultRouter
 
 router = OptionalSlashDefaultRouter()
@@ -27,12 +27,6 @@ runs_router.register(r'lims', RunDataLIMSViewSet, basename='run-lims')
 runs_router.register(r's3', RunDataS3ObjectViewSet, basename='run-s3')
 runs_router.register(r'gds', RunDataGDSFileViewSet, basename='run-gds')
 
-reports_router = routers.NestedDefaultRouter(router, r'reports', lookup='report')
-reports_router.register(r'subject', ReportSubjectViewSet, basename='report-subject')
-reports_router.register(r'sample', ReportSubjectViewSet, basename='report-subject')
-reports_router.register(r'library', ReportSubjectViewSet, basename='report-subject')
-reports_router.register(r'type', ReportSubjectViewSet, basename='report-subject')
-
 urlpatterns = [
     path('files', views.search_file, name='file-search'),
     path('file-signed-url', views.sign_s3_file, name='file-signed-url'),
@@ -40,7 +34,6 @@ urlpatterns = [
     path('', include(router.urls)),
     path('', include(subjects_router.urls)),
     path('', include(runs_router.urls)),
-    path('', include(reports_router.urls))
 ]
 
 handler500 = 'rest_framework.exceptions.server_error'

--- a/data_portal/urls.py
+++ b/data_portal/urls.py
@@ -4,7 +4,7 @@ from rest_framework_nested import routers
 from data_portal import views
 from .viewsets import LIMSRowViewSet, S3ObjectViewSet, BucketViewSet, SubjectViewSet, SubjectS3ObjectViewSet, \
     RunViewSet, PresignedUrlViewSet, RunDataLIMSViewSet, RunDataS3ObjectViewSet, SubjectGDSFileViewSet, \
-    RunDataGDSFileViewSet, GDSFileViewSet, ReportViewSet
+    RunDataGDSFileViewSet, GDSFileViewSet, ReportViewSet, ReportSubjectViewSet
 from .routers import OptionalSlashDefaultRouter
 
 router = OptionalSlashDefaultRouter()
@@ -26,6 +26,9 @@ runs_router = routers.NestedDefaultRouter(router, r'runs', lookup='run')
 runs_router.register(r'lims', RunDataLIMSViewSet, basename='run-lims')
 runs_router.register(r's3', RunDataS3ObjectViewSet, basename='run-s3')
 runs_router.register(r'gds', RunDataGDSFileViewSet, basename='run-gds')
+
+reports_router = routers.NestedDefaultRouter(router, r'reports', lookup='report')
+reports_router.register(r'subject', ReportSubjectViewSet, basename='report-subject')
 
 urlpatterns = [
     path('files', views.search_file, name='file-search'),

--- a/data_portal/viewsets.py
+++ b/data_portal/viewsets.py
@@ -268,7 +268,7 @@ class RunViewSet(ReadOnlyModelViewSet):
 
 
 class ReportViewSet(ReadOnlyModelViewSet):
-    queryset = Report.objects.values_list('sample_id', named=True).filter(sample_id__isnull=False).distinct()
+    queryset = Report.objects.all()
     serializer_class = ReportIdSerializer
     pagination_class = StandardResultsSetPagination
     filter_backends = [filters.OrderingFilter, filters.SearchFilter]
@@ -277,12 +277,16 @@ class ReportViewSet(ReadOnlyModelViewSet):
     search_fields = ordering_fields
 
     def retrieve(self, request, pk=None, **kwargs):
+        results = Report.objects.all()
+
         data = {
             'id': pk,
             'reports': {
-                'count': Report.objects.count()
+                'count': results.count()
             },
         }
+        data.update(results=ReportIdSerializer(results, many=True).data)
+
         return Response(data)
 
 class ReportSubjectViewSet(ReadOnlyModelViewSet):
@@ -294,11 +298,13 @@ class ReportSubjectViewSet(ReadOnlyModelViewSet):
     ordering = ['-subject_id']
     search_fields = ordering_fields
 
+    results = Report.objects.all()
+
     def retrieve(self, request, pk=None, **kwargs):
         data = {
             'id': pk,
             'subjects': {
-                'count': Report.objects.filter(subject_id=pk)
+                'results': {ReportIdSerializer(results, many=True).data}
             },
         }
         return Response(data)

--- a/data_portal/viewsets.py
+++ b/data_portal/viewsets.py
@@ -13,7 +13,7 @@ from .models import LIMSRow, S3Object, GDSFile, Report
 from .pagination import StandardResultsSetPagination
 from .renderers import content_renderers
 from .serializers import LIMSRowModelSerializer, S3ObjectModelSerializer, SubjectIdSerializer, RunIdSerializer, \
-    BucketIdSerializer, GDSFileModelSerializer, ReportIdSerializer
+    BucketIdSerializer, GDSFileModelSerializer, ReportSerializer
 
 logger = logging.getLogger()
 
@@ -269,45 +269,12 @@ class RunViewSet(ReadOnlyModelViewSet):
 
 class ReportViewSet(ReadOnlyModelViewSet):
     queryset = Report.objects.all()
-    serializer_class = ReportIdSerializer
+    serializer_class = ReportSerializer
     pagination_class = StandardResultsSetPagination
     filter_backends = [filters.OrderingFilter, filters.SearchFilter]
     ordering_fields = '__all__'
     ordering = ['-subject_id']
     search_fields = ordering_fields
-
-    def retrieve(self, request, pk=None, **kwargs):
-        results = Report.objects.all()
-
-        data = {
-            'id': pk,
-            'reports': {
-                'count': results.count()
-            },
-        }
-        data.update(results=ReportIdSerializer(results, many=True).data)
-
-        return Response(data)
-
-class ReportSubjectViewSet(ReadOnlyModelViewSet):
-    queryset = Report.objects.values_list('subject_id', named=True).filter(subject_id__isnull=False).distinct()
-    serializer_class = ReportIdSerializer
-    pagination_class = StandardResultsSetPagination
-    filter_backends = [filters.OrderingFilter, filters.SearchFilter]
-    ordering_fields = ['subject_id']
-    ordering = ['-subject_id']
-    search_fields = ordering_fields
-
-    results = Report.objects.all()
-
-    def retrieve(self, request, pk=None, **kwargs):
-        data = {
-            'id': pk,
-            'subjects': {
-                'results': {ReportIdSerializer(results, many=True).data}
-            },
-        }
-        return Response(data)
 
 
 class RunDataS3ObjectViewSet(ReadOnlyModelViewSet):

--- a/data_portal/viewsets.py
+++ b/data_portal/viewsets.py
@@ -272,7 +272,7 @@ class ReportViewSet(ReadOnlyModelViewSet):
     serializer_class = ReportIdSerializer
     pagination_class = StandardResultsSetPagination
     filter_backends = [filters.OrderingFilter, filters.SearchFilter]
-    ordering_fields = ['sample_id']
+    ordering_fields = '__all__'
     ordering = ['-sample_id']
     search_fields = ordering_fields
 
@@ -281,6 +281,24 @@ class ReportViewSet(ReadOnlyModelViewSet):
             'id': pk,
             'reports': {
                 'count': Report.objects.filter(sample_id=pk).count()
+            },
+        }
+        return Response(data)
+
+class ReportSubjectViewSet(ReadOnlyModelViewSet):
+    queryset = Report.objects.values_list('subject_id', named=True).filter(sample_id__isnull=False).distinct()
+    serializer_class = ReportIdSerializer
+    pagination_class = StandardResultsSetPagination
+    filter_backends = [filters.OrderingFilter, filters.SearchFilter]
+    ordering_fields = ['subject_id']
+    ordering = ['-subject_id']
+    search_fields = ordering_fields
+
+    def retrieve(self, request, pk=None, **kwargs):
+        data = {
+            'id': pk,
+            'data': {
+                'count': Report.objects.filter(sample_id=pk).data
             },
         }
         return Response(data)

--- a/data_portal/viewsets.py
+++ b/data_portal/viewsets.py
@@ -273,20 +273,20 @@ class ReportViewSet(ReadOnlyModelViewSet):
     pagination_class = StandardResultsSetPagination
     filter_backends = [filters.OrderingFilter, filters.SearchFilter]
     ordering_fields = '__all__'
-    ordering = ['-sample_id']
+    ordering = ['-subject_id']
     search_fields = ordering_fields
 
     def retrieve(self, request, pk=None, **kwargs):
         data = {
             'id': pk,
             'reports': {
-                'count': Report.objects.filter(sample_id=pk).count()
+                'count': Report.objects.count()
             },
         }
         return Response(data)
 
 class ReportSubjectViewSet(ReadOnlyModelViewSet):
-    queryset = Report.objects.values_list('subject_id', named=True).filter(sample_id__isnull=False).distinct()
+    queryset = Report.objects.values_list('subject_id', named=True).filter(subject_id__isnull=False).distinct()
     serializer_class = ReportIdSerializer
     pagination_class = StandardResultsSetPagination
     filter_backends = [filters.OrderingFilter, filters.SearchFilter]
@@ -297,8 +297,8 @@ class ReportSubjectViewSet(ReadOnlyModelViewSet):
     def retrieve(self, request, pk=None, **kwargs):
         data = {
             'id': pk,
-            'data': {
-                'count': Report.objects.filter(sample_id=pk).data
+            'subjects': {
+                'count': Report.objects.filter(subject_id=pk)
             },
         }
         return Response(data)


### PR DESCRIPTION
Django browsing for that endpoint takes around 34 seconds **on the browser**. This is bad from a perf perspective but also expected, but not an issue since queries through the CLI/curl are sub-1 second.

This endpoint is therefore meant to be consumed via CLI and when plots/trends and specific patterns in data are interesting, they'll be sketched and ported to the portal UI.

Thanks @victorskl for the help putting this one together!