### PR TITLE
Quick patch to prevent manual workflows from running

### DIFF
--- a/data_processors/pipeline/lambdas/demux_metadata.py
+++ b/data_processors/pipeline/lambdas/demux_metadata.py
@@ -28,6 +28,7 @@ SAMPLE_ID_HEADER = "Sample_ID (SampleSheet)"
 OVERRIDECYCLES_HEADER = "OverrideCycles"
 TYPE_HEADER = "Type"
 ASSAY_HEADER = "Assay"
+WORKFLOW_HEADER = "Workflow"
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -53,7 +54,7 @@ def extract_requested_rows(df, requested_ids: list):
     # filter rows by requested ids
     subset_rows = df[df[SAMPLE_ID_HEADER].isin(requested_ids)]
     # filter colums by data needed for workflow
-    subset_cols = subset_rows[[SAMPLE_ID_HEADER, OVERRIDECYCLES_HEADER, TYPE_HEADER, ASSAY_HEADER]]
+    subset_cols = subset_rows[[SAMPLE_ID_HEADER, OVERRIDECYCLES_HEADER, TYPE_HEADER, ASSAY_HEADER, WORKFLOW_HEADER]]
     return subset_cols
 
 
@@ -137,13 +138,14 @@ def handler(event, context):
 
     # turn metadata_df into format compatible with workflow input
     # Select, rename, split metadata df
-    requested_metadata_df = requested_metadata_df[[SAMPLE_ID_HEADER, OVERRIDECYCLES_HEADER, TYPE_HEADER, ASSAY_HEADER]]
+    requested_metadata_df = requested_metadata_df[[SAMPLE_ID_HEADER, OVERRIDECYCLES_HEADER, TYPE_HEADER, ASSAY_HEADER, WORKFLOW_HEADER]]
     # Rename
     requested_metadata_df.rename(columns={
         SAMPLE_ID_HEADER: "sample",
         OVERRIDECYCLES_HEADER: "override_cycles",
         TYPE_HEADER: "type",
-        ASSAY_HEADER: "assay"
+        ASSAY_HEADER: "assay",
+        WORKFLOW_HEADER: "workflow"
     }, inplace=True)
 
     # Split by records

--- a/data_processors/pipeline/lambdas/orchestrator.py
+++ b/data_processors/pipeline/lambdas/orchestrator.py
@@ -212,7 +212,7 @@ def prepare_germline_jobs(this_batch: Batch, this_batch_run: BatchRun, this_sqr:
         is_manual = False
         for sample_library_name in sample_library_names:
             library_metadata: pd.DataFrame = metadata_df.query(f"sample=='{sample_library_name}'")
-            if library_metadata["workflow"].unique().item() == "manual":
+            if not library_metadata.empty and library_metadata["workflow"].unique().item() == "manual":
                 logger.info(f"Skipping sample '{sample_name}'. Workflow column for matching "
                             f"sample '{sample_library_name}' is set to manual")
                 is_manual = True

--- a/data_processors/pipeline/lambdas/orchestrator.py
+++ b/data_processors/pipeline/lambdas/orchestrator.py
@@ -208,6 +208,20 @@ def prepare_germline_jobs(this_batch: Batch, this_batch_run: BatchRun, this_sqr:
         # collect back BSSH run styled SampleSheet(SampleID) globally unique ID format from rgid
         sample_library_names = list(map(lambda k: k.split('.')[-1], sample_df.rgid.unique().tolist()))
 
+        # Skip samples where metadata workflow is set to manual
+        for sample_library_name in sample_library_names:
+            library_metadata: pd.DataFrame = metadata_df.query(f"sample=='{sample_library_name}'")
+            if library_metadata["workflow"].unique().item() == "manual":
+                is_manual = True
+                break
+        else:
+            is_manual = False
+
+        # Break out of manual
+        if is_manual:
+            # We do not pursue manual samples
+            continue
+
         # iterate through libraries for this sample and collect their assay types
         assay_types = []
         for sample_library_name in sample_library_names:

--- a/data_processors/pipeline/lambdas/orchestrator.py
+++ b/data_processors/pipeline/lambdas/orchestrator.py
@@ -209,17 +209,20 @@ def prepare_germline_jobs(this_batch: Batch, this_batch_run: BatchRun, this_sqr:
         sample_library_names = list(map(lambda k: k.split('.')[-1], sample_df.rgid.unique().tolist()))
 
         # Skip samples where metadata workflow is set to manual
+        is_manual = False
         for sample_library_name in sample_library_names:
             library_metadata: pd.DataFrame = metadata_df.query(f"sample=='{sample_library_name}'")
             if library_metadata["workflow"].unique().item() == "manual":
+                logger.info(f"Skipping sample '{sample_name}'. Workflow column for matching "
+                            f"sample '{sample_library_name}' is set to manual")
                 is_manual = True
                 break
-        else:
-            is_manual = False
 
         # Break out of manual
         if is_manual:
             # We do not pursue manual samples
+            logger.info(f"Skipping sample '{sample_name}'. "
+                        f"Workflow column is set to manual for at least one library name")
             continue
 
         # iterate through libraries for this sample and collect their assay types

--- a/data_processors/pipeline/tests/test_bcl_convert.py
+++ b/data_processors/pipeline/tests/test_bcl_convert.py
@@ -23,7 +23,8 @@ class BCLConvertUnitTests(PipelineUnitTestCase):
                       "sample": "PTC_EXPn200908LL_L2000001",
                       "override_cycles": "Y100;I8N2;I8N2;Y100",
                       "type": "WGS",
-                      "assay": "TsqNano"
+                      "assay": "TsqNano",
+                      "workflow": "research"
                     }
             ]
         )
@@ -146,7 +147,8 @@ class BCLConvertUnitTests(PipelineUnitTestCase):
                 "sample": "",
                 "override_cycles": "Y100;I8N2;I8N2;Y100",
                 "type": "WGS",
-                "assay": "TsqNano"
+                "assay": "TsqNano",
+                "workflow": "research"
               }
             ]
         )

--- a/data_processors/pipeline/tests/test_demux_metadata.py
+++ b/data_processors/pipeline/tests/test_demux_metadata.py
@@ -57,6 +57,9 @@ class DemuxMetaDataTests(PipelineUnitTestCase):
             ],
             demux_metadata.ASSAY_HEADER: [
                 "TsqNano"
+            ],
+            demux_metadata.WORKFLOW_HEADER: [
+                "research"
             ]
         }
         self.mock_metadata_df = pd.DataFrame(data=d)
@@ -94,6 +97,7 @@ class DemuxMetaDataTests(PipelineUnitTestCase):
         self.assertIsNotNone(result[0].get('override_cycles', None))
         self.assertIsNotNone(result[0].get('type', None))
         self.assertIsNotNone(result[0].get('assay', None))
+        self.assertIsNotNone(result[0].get('workflow', None))
 
         logger.info("-" * 32)
         logger.info("Example demux_metadata.handler lambda output:")

--- a/data_processors/pipeline/tests/test_orchestrator.py
+++ b/data_processors/pipeline/tests/test_orchestrator.py
@@ -143,7 +143,8 @@ class OrchestratorUnitTests(PipelineUnitTestCase):
                 "sample": "PRJ200438_LPRJ200438",
                 "override_cycles": "Y100;I8N2;I8N2;Y100",
                 "type": "WGS",
-                "assay": "TsqNano"
+                "assay": "TsqNano",
+                "workflow": "research"
             }
         ])
 

--- a/data_processors/pipeline/tests/test_sqs_iap_event.py
+++ b/data_processors/pipeline/tests/test_sqs_iap_event.py
@@ -197,13 +197,15 @@ class SQSIAPEventUnitTests(PipelineUnitTestCase):
                 "sample": "PTC_EXPn200908LL_L2000001",
                 "override_cycles": "Y100;I8N2;I8N2;Y100",
                 "type": "WGS",
-                "assay": "TsqNano"
+                "assay": "TsqNano",
+                "workflow": "research"
             },
             {
                 "sample": "PTC_EXPn200908LL_L2000001_topup",
                 "override_cycles": "Y100;I8N2;I8N2;Y100",
                 "type": "WGS",
-                "assay": "TsqNano"
+                "assay": "TsqNano",
+                "workflow": "research"
             },
         ])
 


### PR DESCRIPTION
* Demux metadata now takes the workflow column
* Orchestrator now checks against the metadata df to make sure that the workflow is not manual before continuing with the germline-qc pipeline.

See discussion: https://umccr.slack.com/archives/C8CG6K76W/p1620683101048900

@andrei-seleznev tagged you in, cos not sure how disruptive this is to your metadata work. Is there something in there that could ultimately replace this too?