### PR TITLE
Rolled back Werkzeug to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ make start
 ```
 
 - REST API at: http://localhost:8000
+- Swagger at: http://localhost:8000/swagger/
+- ReDoc at: http://localhost:8000/redoc/
 - Look into `Makefile` for more dev routine targets
 
 #### Testing

--- a/data_portal/settings/aws.py
+++ b/data_portal/settings/aws.py
@@ -21,3 +21,18 @@ db_conn_cfg['OPTIONS'] = {
 DATABASES = {
     'default': db_conn_cfg
 }
+
+CORS_ORIGIN_ALLOW_ALL = False
+CORS_ALLOW_CREDENTIALS = False
+
+CORS_ALLOWED_ORIGINS = [
+    'https://data.umccr.org',
+    'https://data.prod.umccr.org',
+    'https://data.dev.umccr.org',
+]
+
+CSRF_TRUSTED_ORIGINS = [
+    'data.umccr.org',
+    'data.prod.umccr.org',
+    'data.dev.umccr.org',
+]

--- a/data_portal/settings/base.py
+++ b/data_portal/settings/base.py
@@ -157,3 +157,18 @@ XRAY_RECORDER = {
 
 # turn off xray more generally and you can overwrite with env var AWS_XRAY_SDK_ENABLED=true at runtime
 xray.global_sdk_config.set_sdk_enabled(False)
+
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        'Bearer': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header'
+        }
+    },
+    'USE_SESSION_AUTH': False,
+}
+
+REDOC_SETTINGS = {
+   'LAZY_RENDERING': False,
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aws-xray-sdk==2.8.0
-boto3==1.17.83
-botocore==1.20.83
+boto3==1.17.84
+botocore==1.20.84
 Django==3.2.3
 django-environ==0.4.5
 django-cors-headers==3.7.0
@@ -8,7 +8,8 @@ djangorestframework==3.12.4
 pymysql==1.0.2
 python-dateutil==2.8.1
 google-auth==1.30.1
-Werkzeug==2.0.1
+# pinned Werkzeug to 1.0.1, pls do not upgrade to v2 yet
+Werkzeug==1.0.1
 libica==0.5.0
 gspread==3.7.0
 gspread-pandas==2.3.0

--- a/serverless.yml
+++ b/serverless.yml
@@ -44,7 +44,7 @@ provider:
         - POST
         - PUT
         - PATCH
-      allowCredentials: true
+      allowCredentials: false
       maxAge: 300
     authorizers:
       cognitoJwtAuthorizer:


### PR DESCRIPTION
* Config explicit CORS and CSRF origins
* Config OpenAPI scheme to use Bearer token
* Bump boto
