### PR TITLE
Updated bclconvert settings for 10x samples

### DIFF
--- a/data_processors/pipeline/lambdas/bcl_convert.py
+++ b/data_processors/pipeline/lambdas/bcl_convert.py
@@ -158,6 +158,8 @@ def get_settings_by_instrument_type_assay(instrument, sample_type, assay):
         settings = ADAPTERS_BY_KIT["nextera"].copy()
         # We also wish to keep the indexes as reads
         settings["create_fastq_for_index_reads"] = True
+        settings["minimum_trimmed_read_length"] = 8
+        settings["mask_short_reads"] = 8
         return settings
 
     # Then if assay is TSO -> return TSO parameters


### PR DESCRIPTION
BCL2Fastq guide here recommends alternative values for `--minimum-trimmed-read-length` and `--mask-short-adapter-reads` to defaults in BCLConvert settings.

https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/bcl2fastq-direct