### PR TITLE
Ct tso automation

### DIFF
--- a/data_processors/pipeline/domain/batch.py
+++ b/data_processors/pipeline/domain/batch.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""batch-ing domain module
+
+Domain models related to Workflow Automation.
+See domain package __init__.py doc string.
+See orchestration package __init__.py doc string.
+
+Impl Note:
+Batcher encapsulate Batch creation logics. It is a loose builder (See Creational pattern).
+Once instantiated, you get a batcher object that has a Batch and related BatchRun.
+You can use it for those jobs (workflows) that wish to run in batch manner and batch notification.
+
+Note that _import_ free here! And also passing X_srv module into the constructor. Power of Python duck typing!
+We could import those respective classes and hint the typing to the caller. Otherwise you know what you are passing
+into the constructor by "naming" convention. That's the lore of pure Pythonic-ism "readability".
+"""
+
+
+class Batcher:
+
+    def __init__(self, workflow, run_step: str, batch_srv, fastq_srv, logger=None):
+        self.workflow = workflow
+        self.run_step = run_step
+        self.batch_srv = batch_srv
+        self.fastq_srv = fastq_srv
+        self.logger = logger
+
+        # things that this Batcher built and hold
+        self.batch = None
+        self.batch_run = None
+        self.sqr = None
+
+        # build it
+        self._build()
+
+    # --- internal behaviours
+
+    def _build(self):
+        self.sqr = self.workflow.sequence_run
+
+        # create a batch if not exist
+        batch_name = self.sqr.name if self.sqr else f"{self.workflow.type_name}__{self.workflow.wfr_id}"
+        self.batch = self.batch_srv.get_or_create_batch(name=batch_name, created_by=self.workflow.wfr_id)
+
+        # register a new batch run for this_batch's run step
+        self.batch_run = self.batch_srv.skip_or_create_batch_run(
+            batch=self.batch,
+            run_step=self.run_step,
+        )
+
+        if self.batch_run is not None:
+            self._prepare_batch_context()
+
+    def _prepare_batch_context(self):
+        if self.batch.context_data is None:
+            # cache batch context data in db
+            fastq_list_rows = self.fastq_srv.get_fastq_list_row_by_sequence_name(self.sqr.name)
+            self.batch = self.batch_srv.update_batch(self.batch.id, context_data=fastq_list_rows)
+
+    # --- external behaviours
+
+    def get_skip_message(self):
+        # skip the request if there is on going existing batch_run for the same batch run step
+        # this is especially to fence off duplicate ICA WES events hitting multiple time to our ICA event lambda
+        msg = f"SKIP. THERE IS EXISTING ON GOING RUN FOR BATCH " \
+              f"ID: {self.batch.id}, NAME: {self.batch.name}, CREATED_BY: {self.batch.created_by}"
+        if self.logger is not None:
+            self.logger.warning(msg)
+        return {'message': msg}
+
+    def reset_batch_run(self):
+        self.batch_run = self.batch_srv.reset_batch_run(self.batch_run.id)
+
+    def get_status(self):
+        return {
+            'batch_id': self.batch.id,
+            'batch_name': self.batch.name,
+            'batch_created_by': self.batch.created_by,
+            'batch_run_id': self.batch_run.id,
+            'batch_run_step': self.batch_run.step,
+            'batch_run_status': "RUNNING" if self.batch_run.running else "NOT_RUNNING"
+        }

--- a/data_processors/pipeline/domain/config.py
+++ b/data_processors/pipeline/domain/config.py
@@ -11,4 +11,5 @@ ICA_WORKFLOW_PREFIX = "/iap/workflow"
 
 SQS_TN_QUEUE_ARN = "/data_portal/backend/sqs_tumor_normal_queue_arn"
 SQS_DRAGEN_WGS_QC_QUEUE_ARN = "/data_portal/backend/sqs_dragen_wgs_qc_queue_arn"
+SQS_DRAGEN_TSO_CTDNA_QUEUE_ARN = "/data_portal/backend/sqs_ct_tso_queue_arn"
 SQS_NOTIFICATION_QUEUE_ARN = "/data_portal/backend/sqs_notification_queue_arn"

--- a/data_processors/pipeline/domain/config.py
+++ b/data_processors/pipeline/domain/config.py
@@ -11,5 +11,5 @@ ICA_WORKFLOW_PREFIX = "/iap/workflow"
 
 SQS_TN_QUEUE_ARN = "/data_portal/backend/sqs_tumor_normal_queue_arn"
 SQS_DRAGEN_WGS_QC_QUEUE_ARN = "/data_portal/backend/sqs_dragen_wgs_qc_queue_arn"
-SQS_DRAGEN_TSO_CTDNA_QUEUE_ARN = "/data_portal/backend/sqs_ct_tso_queue_arn"
+SQS_DRAGEN_TSO_CTDNA_QUEUE_ARN = "/data_portal/backend/sqs_dragen_tso_ctdna_queue_arn"
 SQS_NOTIFICATION_QUEUE_ARN = "/data_portal/backend/sqs_notification_queue_arn"

--- a/data_processors/pipeline/domain/workflow.py
+++ b/data_processors/pipeline/domain/workflow.py
@@ -33,7 +33,7 @@ class WorkflowType(Enum):
     BCL_CONVERT = "bcl_convert"
     DRAGEN_WGS_QC = "dragen_wgs_qc"
     TUMOR_NORMAL = "tumor_normal"
-    CTTSO = "dragen_cttso"
+    DRAGEN_TSO_CTDNA = "dragen_tso_ctdna"
 
 
 class WorkflowStatus(Enum):

--- a/data_processors/pipeline/domain/workflow.py
+++ b/data_processors/pipeline/domain/workflow.py
@@ -33,6 +33,7 @@ class WorkflowType(Enum):
     BCL_CONVERT = "bcl_convert"
     DRAGEN_WGS_QC = "dragen_wgs_qc"
     TUMOR_NORMAL = "tumor_normal"
+    CTTSO = "ctTSO"
 
 
 class WorkflowStatus(Enum):
@@ -74,7 +75,13 @@ class WorkflowHelper(Helper):
     def construct_workflow_name(self, **kwargs):
         # pattern: [AUTOMATION_PREFIX]__[WORKFLOW_TYPE]__[WORKFLOW_SPECIFIC_PART]__[UTC_TIMESTAMP]
         utc_now_ts = int(datetime.utcnow().replace(tzinfo=timezone.utc).timestamp())
-        if self.type == WorkflowType.DRAGEN_WGS_QC:
+        # Primary analysis
+        if self.type == WorkflowType.BCL_CONVERT:
+            seq_name = kwargs['seq_name']
+            seq_run_id = kwargs['seq_run_id']
+            return f"{WorkflowHelper.prefix}__{self.type.value}__{seq_name}__{seq_run_id}__{utc_now_ts}"
+        # Secondary analysis
+        elif self.type in [ WorkflowType.DRAGEN_WGS_QC, WorkflowType.CTTSO ]:
             seq_name = kwargs['seq_name']
             seq_run_id = kwargs['seq_run_id']
             sample_name = kwargs['sample_name']
@@ -82,9 +89,5 @@ class WorkflowHelper(Helper):
         elif self.type == WorkflowType.TUMOR_NORMAL:
             subject_id = kwargs['subject_id']
             return f"{WorkflowHelper.prefix}__{self.type.value}__{subject_id}__{utc_now_ts}"
-        elif self.type == WorkflowType.BCL_CONVERT:
-            seq_name = kwargs['seq_name']
-            seq_run_id = kwargs['seq_run_id']
-            return f"{WorkflowHelper.prefix}__{self.type.value}__{seq_name}__{seq_run_id}__{utc_now_ts}"
         else:
             raise ValueError(f"Unsupported workflow type: {self.type.name}")

--- a/data_processors/pipeline/domain/workflow.py
+++ b/data_processors/pipeline/domain/workflow.py
@@ -33,7 +33,7 @@ class WorkflowType(Enum):
     BCL_CONVERT = "bcl_convert"
     DRAGEN_WGS_QC = "dragen_wgs_qc"
     TUMOR_NORMAL = "tumor_normal"
-    CTTSO = "ctTSO"
+    CTTSO = "dragen_cttso"
 
 
 class WorkflowStatus(Enum):

--- a/data_processors/pipeline/domain/workflow.py
+++ b/data_processors/pipeline/domain/workflow.py
@@ -81,7 +81,7 @@ class WorkflowHelper(Helper):
             seq_run_id = kwargs['seq_run_id']
             return f"{WorkflowHelper.prefix}__{self.type.value}__{seq_name}__{seq_run_id}__{utc_now_ts}"
         # Secondary analysis
-        elif self.type in [ WorkflowType.DRAGEN_WGS_QC, WorkflowType.CTTSO ]:
+        elif self.type in [ WorkflowType.DRAGEN_WGS_QC, WorkflowType.DRAGEN_TSO_CTDNA ]:
             seq_name = kwargs['seq_name']
             seq_run_id = kwargs['seq_run_id']
             sample_name = kwargs['sample_name']

--- a/data_processors/pipeline/lambdas/ct_tso.py
+++ b/data_processors/pipeline/lambdas/ct_tso.py
@@ -190,7 +190,7 @@ def handler(event, context) -> dict:
             'wfl_id': workflow_id,
             'wfr_id': wfl_run['id'],
             'wfv_id': wfl_run['workflow_version']['id'],
-            'type': WorkflowType.GERMLINE,
+            'type': WorkflowType.CTTSO,
             'version': workflow_version,
             'input': workflow_input,
             'start': wfl_run.get('time_started'),

--- a/data_processors/pipeline/lambdas/ct_tso.py
+++ b/data_processors/pipeline/lambdas/ct_tso.py
@@ -1,0 +1,218 @@
+try:
+    import unzip_requirements
+except ImportError:
+    pass
+
+import django
+import os
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'data_portal.settings.base')
+django.setup()
+
+# ---
+
+# Standards
+import copy
+import logging
+from datetime import datetime, timezone
+
+# Data portal imports
+from data_portal.models import Workflow
+from data_processors.pipeline import services
+from data_processors.pipeline.constant import WorkflowType, WorkflowHelper
+from data_processors.pipeline.lambdas import wes_handler
+
+# Utils imports
+from utils import libjson, libssm, libdt
+
+# Set loggers
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def sqs_handler(event, context):
+    """event payload dict
+    {
+        'Records': [
+            {
+                'messageId': "11d6ee51-4cc7-4302-9e22-7cd8afdaadf5",
+                'body': "{\"JSON\": \"Formatted Message\"}",
+                'messageAttributes': {},
+                'md5OfBody': "e4e68fb7bd0e697a0ae8f1bb342846b3",
+                'eventSource': "aws:sqs",
+                'eventSourceARN': "arn:aws:sqs:us-east-2:123456789012:fifo.fifo",
+            },
+            ...
+        ]
+    }
+
+    Details event payload dict refer to https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+    Backing queue is FIFO queue and, guaranteed delivery-once, no duplication.
+
+    :param event:
+    :param context:
+    :return:
+    """
+    messages = event['Records']
+
+    results = []
+    for message in messages:
+        job = libjson.loads(message['body'])
+        results.append(handler(job, context))
+
+    return {
+        'results': results
+    }
+
+
+def handler(event, context) -> dict:
+    """event payload dict
+    {
+        "tso500_sample": {
+            "sample_id": "sample_id",
+            "sample_name": "sample_name",
+            "sample_type": "DNA",
+            "pair_id": "sample_name"
+        },
+        "fastq_list_rows": [{
+            "rgid": "index1.index2.lane",
+            "rgsm": "sample_name",
+            "rglb": "UnknownLibrary",
+            "lane": int,
+            "read_1": {
+              "class": "File",
+              "location": "gds://path/to/read_1.fastq.gz"
+            },
+            "read_2": {
+              "class": "File",
+              "location": "gds://path/to/read_2.fastq.gz"
+            }
+        }],
+        "samplesheet": {
+          "class": "File",
+          "location": "gds://path/to/samplesheet"
+        },
+        "run_info_xml": {
+          "class": "File",
+          "location": "path/to/dir/RunInfo.xml"
+        },
+        "run_parameters_xml": {
+          "class": "File",
+          "location": "path/to/dir/RunParameters.xml"
+        },
+        "batch_run_id": "batch run id",
+    }
+
+    :param event:
+    :param context:
+    :return: workflow db record id, wfr_id, sample_name in JSON string
+    """
+
+    logger.info(f"Start processing {WorkflowType.CTTSO.name} event")
+    logger.info(libjson.dumps(event))
+
+    # Set sequence run id
+    seq_run_id = event.get('seq_run_id', None)
+    seq_name = event.get('seq_name', None)
+    # Set batch run id
+    batch_run_id = event.get('batch_run_id', None)
+    # Get sample name
+    sample_name = event['tso500_sample']['sample_name']
+
+    # Set workflow helper
+    wfl_helper = WorkflowHelper(WorkflowType.CTTSO)
+
+    # Read input template from parameter store
+    input_template = libssm.get_ssm_param(wfl_helper.get_ssm_key_input())
+    workflow_input: dict = copy.deepcopy(libjson.loads(input_template))
+    workflow_input['tso500_samples'] = [event['tso500_sample']]
+    workflow_input['fastq_list_rows'] = event['fastq_list_rows']
+    workflow_input['samplesheet'] = event['samplesheet']
+    workflow_input['run_info_xml'] = event['run_info_xml']
+    workflow_input['run_parameters_xml'] = event['run_parameters_xml']
+
+    # read workflow id and version from parameter store
+    workflow_id = libssm.get_ssm_param(wfl_helper.get_ssm_key_id())
+    workflow_version = libssm.get_ssm_param(wfl_helper.get_ssm_key_version())
+
+    sqr = services.get_sequence_run_by_run_id(seq_run_id) if seq_run_id else None
+    batch_run = services.get_batch_run(batch_run_id=batch_run_id) if batch_run_id else None
+
+    matched_runs = services.search_matching_runs(
+        type_name=WorkflowType.CTTSO.name,
+        wfl_id=workflow_id,
+        version=workflow_version,
+        sample_name=sample_name,
+        sequence_run=sqr,
+        batch_run=batch_run
+    )
+
+    if len(matched_runs) > 0:
+        results = []
+        for workflow in matched_runs:
+            result = {
+                'sample_name': workflow.sample_name,
+                'id': workflow.id,
+                'wfr_id': workflow.wfr_id,
+                'wfr_name': workflow.wfr_name,
+                'status': workflow.end_status,
+                'start': libdt.serializable_datetime(workflow.start),
+                'sequence_run_id': workflow.sequence_run.id if sqr else None,
+                'batch_run_id': workflow.batch_run.id if batch_run else None,
+            }
+            results.append(result)
+        results_dict = {
+            'status': "SKIPPED",
+            'reason': "Matching workflow runs found",
+            'event': libjson.dumps(event),
+            'matched_runs': results
+        }
+        logger.info(libjson.dumps(results_dict))
+        return results_dict
+
+    # construct and format workflow run name convention
+    workflow_run_name = wfl_helper.construct_workflow_name(
+        seq_name=seq_name,
+        seq_run_id=seq_run_id,
+        sample_name=sample_name
+    )
+
+    wfl_run = wes_handler.launch({
+        'workflow_id': workflow_id,
+        'workflow_version': workflow_version,
+        'workflow_run_name': workflow_run_name,
+        'workflow_input': workflow_input,
+    }, context)
+
+    workflow: Workflow = services.create_or_update_workflow(
+        {
+            'wfr_name': workflow_run_name,
+            'wfl_id': workflow_id,
+            'wfr_id': wfl_run['id'],
+            'wfv_id': wfl_run['workflow_version']['id'],
+            'type': WorkflowType.GERMLINE,
+            'version': workflow_version,
+            'input': workflow_input,
+            'start': wfl_run.get('time_started'),
+            'end_status': wfl_run.get('status'),
+            'sequence_run': sqr,
+            'sample_name': sample_name,
+            'batch_run': batch_run,
+        }
+    )
+
+    # notification shall trigger upon wes.run event created action in workflow_update lambda
+
+    result = {
+        'tso500_sample_objs': workflow.tso500_samples,
+        'id': workflow.id,
+        'wfr_id': workflow.wfr_id,
+        'wfr_name': workflow.wfr_name,
+        'status': workflow.end_status,
+        'start': libdt.serializable_datetime(workflow.start),
+        'batch_run_id': workflow.batch_run.id if batch_run else None,
+    }
+
+    logger.info(libjson.dumps(result))
+
+    return result

--- a/data_processors/pipeline/lambdas/dragen_tso_ctdna.py
+++ b/data_processors/pipeline/lambdas/dragen_tso_ctdna.py
@@ -108,7 +108,7 @@ def handler(event, context) -> dict:
     :return: workflow db record id, wfr_id, sample_name in JSON string
     """
 
-    logger.info(f"Start processing {WorkflowType.CTTSO.name} event")
+    logger.info(f"Start processing {WorkflowType.DRAGEN_TSO_CTDNA.name} event")
     logger.info(libjson.dumps(event))
 
     # Set sequence run id
@@ -120,7 +120,7 @@ def handler(event, context) -> dict:
     sample_name = event['tso500_sample']['sample_name']
 
     # Set workflow helper
-    wfl_helper = WorkflowHelper(WorkflowType.CTTSO)
+    wfl_helper = WorkflowHelper(WorkflowType.DRAGEN_TSO_CTDNA)
 
     # Read input template from parameter store
     input_template = libssm.get_ssm_param(wfl_helper.get_ssm_key_input())
@@ -139,7 +139,7 @@ def handler(event, context) -> dict:
     batch_run = services.get_batch_run(batch_run_id=batch_run_id) if batch_run_id else None
 
     matched_runs = services.search_matching_runs(
-        type_name=WorkflowType.CTTSO.name,
+        type_name=WorkflowType.DRAGEN_TSO_CTDNA.name,
         wfl_id=workflow_id,
         version=workflow_version,
         sample_name=sample_name,
@@ -190,7 +190,7 @@ def handler(event, context) -> dict:
             'wfl_id': workflow_id,
             'wfr_id': wfl_run['id'],
             'wfv_id': wfl_run['workflow_version']['id'],
-            'type': WorkflowType.CTTSO,
+            'type': WorkflowType.DRAGEN_TSO_CTDNA,
             'version': workflow_version,
             'input': workflow_input,
             'start': wfl_run.get('time_started'),

--- a/data_processors/pipeline/lambdas/dragen_tso_ctdna.py
+++ b/data_processors/pipeline/lambdas/dragen_tso_ctdna.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 # Data portal imports
 from data_portal.models import Workflow
 from data_processors.pipeline import services
-from data_processors.pipeline.constant import WorkflowType, WorkflowHelper
+from data_processors.pipeline.domain.workflow import WorkflowType, WorkflowHelper
 from data_processors.pipeline.lambdas import wes_handler
 
 # Utils imports

--- a/data_processors/pipeline/lambdas/orchestrator.py
+++ b/data_processors/pipeline/lambdas/orchestrator.py
@@ -26,7 +26,7 @@ import logging
 
 from data_portal.models import Workflow, SequenceRun
 from data_processors.pipeline.services import workflow_srv
-from data_processors.pipeline.orchestration import dragen_wgs_qc_step, tumor_normal_step, google_lims_update_step, ct_tso_step
+from data_processors.pipeline.orchestration import dragen_wgs_qc_step, tumor_normal_step, google_lims_update_step, dragen_tso_ctdna_step
 from data_processors.pipeline.domain.workflow import WorkflowType, WorkflowStatus
 from data_processors.pipeline.lambdas import workflow_update
 from utils import libjson
@@ -109,7 +109,7 @@ def next_step(this_workflow: Workflow, context):
 
         google_lims_update_step.perform(this_workflow)
 
-        return [dragen_wgs_qc_step.perform(this_sqr, this_workflow), ct_tso_step.perform(this_sqr, this_workflow)]
+        return [dragen_wgs_qc_step.perform(this_sqr, this_workflow), dragen_tso_ctdna_step.perform(this_sqr, this_workflow)]
 
     elif this_workflow.type_name.lower() == WorkflowType.DRAGEN_WGS_QC.value.lower():
 

--- a/data_processors/pipeline/lambdas/tests/test_dragen_tso_ctdna.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_tso_ctdna.py
@@ -1,0 +1,269 @@
+import json
+from datetime import datetime
+
+from django.utils.timezone import make_aware
+from libica.openapi import libwes
+from mockito import when
+
+from data_portal.models import Workflow, SequenceRun, BatchRun
+from data_portal.tests.factories import SequenceRunFactory, TestConstant, BatchRunFactory
+from data_processors.pipeline.domain.workflow import WorkflowStatus, WorkflowType, WorkflowHelper
+from data_processors.pipeline.lambdas import dragen_tso_ctdna
+from data_processors.pipeline.tests.case import logger, PipelineUnitTestCase, PipelineIntegrationTestCase
+from utils import libjson, libssm
+
+
+class DragenTsoCtDnaTests(PipelineUnitTestCase):
+
+    def test_handler(self):
+        """
+        python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_tso_ctdna.DragenTsoCtDnaTests.test_handler
+        """
+        mock_sqr: SequenceRun = SequenceRunFactory()
+
+        workflow: dict = dragen_tso_ctdna.handler({
+            "tso500_sample": {
+                "sample_id": "sample_id",
+                "sample_name": "sample_name",
+                "sample_type": "DNA",
+                "pair_id": "sample_name"
+            },
+            "fastq_list_rows": [
+                {
+                    "rgid": "index1.index2.lane",
+                    "rgsm": "sample_name",
+                    "rglb": "sample_library",
+                    "lane": 1,
+                    "read_1": {
+                      "class": "File",
+                      "location": "gds://path/to/read_1.fastq.gz"
+                    },
+                    "read_2": {
+                      "class": "File",
+                      "location": "gds://path/to/read_2.fastq.gz"
+                    }
+                }
+            ],
+            "samplesheet": {
+                "class": "File",
+                "location": "gds://path/to/samplesheet"
+            },
+            "run_info_xml": {
+                "class": "File",
+                "location": "path/to/dir/RunInfo.xml"
+            },
+            "run_parameters_xml": {
+                "class": "File",
+                "location": "path/to/dir/RunParameters.xml"
+            },
+            "seq_run_id": mock_sqr.run_id,
+            "seq_name": mock_sqr.name,
+        }, None)
+
+        logger.info("-" * 32)
+        logger.info("Example dragen_tso_ctdna.handler lambda output:")
+        logger.info(json.dumps(workflow))
+
+        # assert DRAGEN_TSO_CTDNA_QC workflow launch success and save workflow run in db
+        workflows = Workflow.objects.all()
+        self.assertEqual(1, workflows.count())
+
+    def test_handler_alt(self):
+        """
+        python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_tso_ctdna.DragenTsoCtDnaTests.test_handler_alt
+        """
+        mock_sqr: SequenceRun = SequenceRunFactory()
+
+        mock_wfr: libwes.WorkflowRun = libwes.WorkflowRun()
+        mock_wfr.id = TestConstant.wfr_id.value
+        mock_wfr.time_started = make_aware(datetime.utcnow())
+        mock_wfr.status = WorkflowStatus.RUNNING.value
+        workflow_version: libwes.WorkflowVersion = libwes.WorkflowVersion()
+        workflow_version.id = TestConstant.wfv_id.value
+        mock_wfr.workflow_version = workflow_version
+        when(libwes.WorkflowVersionsApi).launch_workflow_version(...).thenReturn(mock_wfr)
+
+        workflow: dict = dragen_tso_ctdna.handler({
+            "tso500_sample": {
+                "sample_id": "sample_id",
+                "sample_name": "sample_name",
+                "sample_type": "DNA",
+                "pair_id": "sample_name"
+            },
+            "fastq_list_rows": [
+                {
+                    "rgid": "index1.index2.lane",
+                    "rgsm": "sample_name",
+                    "rglb": "sample_library",
+                    "lane": 1,
+                    "read_1": {
+                      "class": "File",
+                      "location": "gds://path/to/read_1.fastq.gz"
+                    },
+                    "read_2": {
+                      "class": "File",
+                      "location": "gds://path/to/read_2.fastq.gz"
+                    }
+                }
+            ],
+            "samplesheet": {
+                "class": "File",
+                "location": "gds://path/to/samplesheet"
+            },
+            "run_info_xml": {
+                "class": "File",
+                "location": "path/to/dir/RunInfo.xml"
+            },
+            "run_parameters_xml": {
+                "class": "File",
+                "location": "path/to/dir/RunParameters.xml"
+            },
+            "seq_run_id": mock_sqr.run_id,
+            "seq_name": mock_sqr.name,
+        }, None)
+        logger.info("-" * 32)
+        logger.info("Example dragen_tso_ctdna.handler lambda output:")
+        logger.info(json.dumps(workflow))
+
+        # assert DRAGEN_TSO_CTDNA_QC workflow launch success and save workflow run in db
+        workflows = Workflow.objects.all()
+        self.assertEqual(1, workflows.count())
+
+    def test_handler_skipped(self):
+        """
+        python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_tso_ctdna.DragenTsoCtDnaTests.test_handler_skipped
+        """
+        mock_sqr: SequenceRun = SequenceRunFactory()
+        mock_batch_run: BatchRun = BatchRunFactory()
+
+        wfl_helper = WorkflowHelper(WorkflowType.DRAGEN_TSO_CTDNA)
+
+        mock_dragen_tso_ctdna = Workflow()
+        mock_dragen_tso_ctdna.type_name = WorkflowType.DRAGEN_TSO_CTDNA.name
+        mock_dragen_tso_ctdna.wfl_id = libssm.get_ssm_param(wfl_helper.get_ssm_key_id())
+        mock_dragen_tso_ctdna.version = libssm.get_ssm_param(wfl_helper.get_ssm_key_version())
+        mock_dragen_tso_ctdna.sample_name = "SAMPLE_NAME"
+        mock_dragen_tso_ctdna.sequence_run = mock_sqr
+        mock_dragen_tso_ctdna.batch_run = mock_batch_run
+        mock_dragen_tso_ctdna.start = make_aware(datetime.utcnow())
+        mock_dragen_tso_ctdna.input = libjson.dumps({'mock': "MOCK_INPUT_JSON"})
+        mock_dragen_tso_ctdna.save()
+
+        result: dict = dragen_tso_ctdna.handler({
+            "tso500_sample": {
+                "sample_id": "sample_id",
+                "sample_name": "sample_name",
+                "sample_type": "DNA",
+                "pair_id": "sample_name"
+            },
+            "fastq_list_rows": [
+                {
+                    "rgid": "index1.index2.lane",
+                    "rgsm": "sample_name",
+                    "rglb": "sample_library",
+                    "lane": 1,
+                    "read_1": {
+                      "class": "File",
+                      "location": "gds://path/to/read_1.fastq.gz"
+                    },
+                    "read_2": {
+                      "class": "File",
+                      "location": "gds://path/to/read_2.fastq.gz"
+                    }
+                }
+            ],
+            "samplesheet": {
+                "class": "File",
+                "location": "gds://path/to/samplesheet"
+            },
+            "run_info_xml": {
+                "class": "File",
+                "location": "path/to/dir/RunInfo.xml"
+            },
+            "run_parameters_xml": {
+                "class": "File",
+                "location": "path/to/dir/RunParameters.xml"
+            },
+            "seq_run_id": mock_sqr.run_id,
+            "seq_name": mock_sqr.name,
+        }, None)
+
+        logger.info("-" * 32)
+        logger.info("Example dragen_tso_ctdna.handler lambda output:")
+        logger.info(json.dumps(result))
+        self.assertEqual('SKIPPED', result['status'])
+
+        workflows = Workflow.objects.all()
+        self.assertEqual(1, workflows.count())
+
+    def test_sqs_handler(self):
+        """
+        python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_tso_ctdna.DragenTsoCtDnaTests.test_sqs_handler
+        """
+
+        mock_sqr: SequenceRun = SequenceRunFactory()
+
+        mock_job = {
+            "tso500_sample": {
+                "sample_id": "sample_id",
+                "sample_name": "sample_name",
+                "sample_type": "DNA",
+                "pair_id": "sample_name"
+            },
+            "fastq_list_rows": [
+                {
+                    "rgid": "index1.index2.lane",
+                    "rgsm": "sample_name",
+                    "rglb": "sample_library",
+                    "lane": 1,
+                    "read_1": {
+                      "class": "File",
+                      "location": "gds://path/to/read_1.fastq.gz"
+                    },
+                    "read_2": {
+                      "class": "File",
+                      "location": "gds://path/to/read_2.fastq.gz"
+                    }
+                }
+            ],
+            "samplesheet": {
+                "class": "File",
+                "location": "gds://path/to/samplesheet"
+            },
+            "run_info_xml": {
+                "class": "File",
+                "location": "path/to/dir/RunInfo.xml"
+            },
+            "run_parameters_xml": {
+                "class": "File",
+                "location": "path/to/dir/RunParameters.xml"
+            },
+            "seq_run_id": mock_sqr.run_id,
+            "seq_name": mock_sqr.name,
+            "batch_run_id": 1
+        }
+
+        mock_event = {
+            'Records': [
+                {
+                    'messageId': "11d6ee51-4cc7-4302-9e22-7cd8afdaadf5",
+                    'body': libjson.dumps(mock_job),
+                    'messageAttributes': {},
+                    'md5OfBody': "e4e68fb7bd0e697a0ae8f1bb342846b3",
+                    'eventSource': "aws:sqs",
+                    'eventSourceARN': "arn:aws:sqs:us-east-2:123456789012:fifo.fifo",
+                },
+            ]
+        }
+
+        results = dragen_tso_ctdna.sqs_handler(mock_event, None)
+        logger.info("-" * 32)
+        logger.info("Example dragen_tso_ctdna.sqs_handler lambda output:")
+        logger.info(json.dumps(results))
+
+        self.assertEqual(len(results), 1)
+
+
+class DragenTsoCtDnaIntegrationTests(PipelineIntegrationTestCase):
+    # write test case here if to actually hit IAP endpoints
+    pass

--- a/data_processors/pipeline/lambdas/tests/test_sqs_iap_event.py
+++ b/data_processors/pipeline/lambdas/tests/test_sqs_iap_event.py
@@ -548,7 +548,7 @@ class SQSIAPEventUnitTests(PipelineUnitTestCase):
         )
 
         self.assertEqual(1, Workflow.objects.all().count())
-        self.assertEqual(1, BatchRun.objects.count())
+        self.assertTrue(BatchRun.objects.count() > 1)
 
         logger.info(f"-"*32)
         for wfl in Workflow.objects.all():

--- a/data_processors/pipeline/orchestration/ct_tso_step.py
+++ b/data_processors/pipeline/orchestration/ct_tso_step.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+"""wgs_qc_step module
+
+See domain package __init__.py doc string.
+See orchestration package __init__.py doc string.
+"""
+import logging
+from typing import List
+
+import pandas as pd
+
+from data_portal.models import Batch, BatchRun, SequenceRun, LabMetadata, LabMetadataPhenotype, LabMetadataWorkflow, \
+    LabMetadataType
+from data_processors.pipeline.domain.config import SQS_GERMLINE_QUEUE_ARN
+from data_processors.pipeline.domain.workflow import WorkflowType
+from data_processors.pipeline.lambdas import fastq_list_row
+from data_processors.pipeline.services import batch_srv, fastq_srv
+from data_processors.pipeline.tools import liborca
+from utils import libssm, libsqs, libjson
+from pathlib import Path
+import re
+
+# GLOBALS
+SAMPLESHEET_ASSAY_TYPE_REGEX = r"^(?:SampleSheet\.)(\S+)(?:\.csv)$"
+CTTSO_ASSAY_TYPE = "ctDNA_ctTSO"
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def perform(this_sqr, this_workflow):
+    # create a batch if not exist
+    batch_name = this_sqr.name if this_sqr else f"{this_workflow.type_name}__{this_workflow.wfr_id}"
+    this_batch = batch_srv.get_or_create_batch(name=batch_name, created_by=this_workflow.wfr_id)
+
+    # register a new batch run for this_batch run step
+    this_batch_run = batch_srv.skip_or_create_batch_run(
+        batch=this_batch,
+        run_step=WorkflowType.CTTSO.value.upper()
+    )
+    if this_batch_run is None:
+        # skip the request if there is on going existing batch_run for the same batch run step
+        # this is especially to fence off duplicate IAP WES events hitting multiple time to our IAP event lambda
+        msg = f"SKIP. THERE IS EXISTING ON GOING RUN FOR BATCH " \
+              f"ID: {this_batch.id}, NAME: {this_batch.name}, CREATED_BY: {this_batch.created_by}"
+        logger.warning(msg)
+        return {'message': msg}
+
+    try:
+        if this_batch.context_data is None:
+            # parse bcl convert output and get all output locations
+            bcl_convert_output_obj = liborca.parse_bcl_convert_output(this_workflow.output)
+            # build a sample info and its related fastq locations
+            fastq_list_rows: List = fastq_list_row.handler({
+                'fastq_list_rows': bcl_convert_output_obj,
+                'seq_name': this_sqr.name,
+            }, None)
+
+            # cache batch context data in db
+            this_batch = batch_srv.update_batch(this_batch.id, context_data=fastq_list_rows)
+
+            # Initialise fastq list rows object in model
+            for row in fastq_list_rows:
+                fastq_srv.create_or_update_fastq_list_row(row, this_sqr)
+
+        # Get samplesheet and run files from bcl run
+        samplesheet = get_ct_tso_samplesheet_from_bcl_convert_output(this_workflow.output)
+        run_info_xml, run_parameters_xml = get_run_xml_files_from_bcl_convert_workflow(this_workflow.input)
+
+        # prepare job list and dispatch to job queue
+        job_list = prepare_ct_tso_jobs(this_batch, this_batch_run, this_sqr, samplesheet, run_info_xml, run_parameters_xml)
+        if job_list:
+            queue_arn = libssm.get_ssm_param(SQS_GERMLINE_QUEUE_ARN)
+            libsqs.dispatch_jobs(queue_arn=queue_arn, job_list=job_list)
+        else:
+            batch_srv.reset_batch_run(this_batch_run.id)  # reset running if job_list is empty
+
+    except Exception as e:
+        batch_srv.reset_batch_run(this_batch_run.id)  # reset running
+        raise e
+
+    return {
+        'batch_id': this_batch.id,
+        'batch_name': this_batch.name,
+        'batch_created_by': this_batch.created_by,
+        'batch_run_id': this_batch_run.id,
+        'batch_run_step': this_batch_run.step,
+        'batch_run_status': "RUNNING" if this_batch_run.running else "NOT_RUNNING"
+    }
+
+
+def prepare_ct_tso_jobs(this_batch: Batch, this_batch_run: BatchRun, this_sqr: SequenceRun, samplesheet, run_info_xml, run_parameters_xml) -> List[dict]:
+    """
+    NOTE: This launches the cttso cwl workflow that mimics the ISL workflow
+    See Example IAP Run > Inputs
+    https://github.com/umccr-illumina/cwl-iap/blob/master/.github/tool-help/development/wfl.5cc28c147e4e4dfa9e418523188aacec/3.7.5--1.3.5.md
+
+    Germline job preparation is at _pure_ Library level aggregate.
+    Here "Pure" Library ID means without having _topup(N) or _rerun(N) suffixes.
+    The fastq_list_row lambda already stripped these topup/rerun suffixes (i.e. what is in this_batch.context_data cache).
+    Therefore, it aggregates all fastq list at
+        - per sequence run by per library for
+            - all different lane(s)
+            - all topup(s)
+            - all rerun(s)
+    This constitute one Germline job (i.e. one Germline workflow run).
+
+    See OrchestratorIntegrationTests.test_prepare_germline_jobs() for example job list of SEQ-II validation run.
+
+    :param this_batch:
+    :param this_batch_run:
+    :param this_sqr:
+    :return:
+    """
+    job_list = []
+    fastq_list_rows: List[dict] = libjson.loads(this_batch.context_data)
+
+    # iterate through each sample group by rglb
+    for rglb, rglb_df in pd.DataFrame(fastq_list_rows).groupby("rglb"):
+        # Check rgsm is identical
+        # .item() will raise error if there exists more than one sample name for a given library
+        rgsm = rglb_df['rgsm'].unique().item()
+        # Sample ID
+        samplesheet_sample_id = rglb_df['rgid'].apply(lambda x: x.rsplit(".", 1)[-1]).unique().item()
+        # Get the metadata for the library
+        # NOTE: this will use the library base ID (i.e. without topup/rerun extension), as the metadata is the same
+        lib_metadata: LabMetadata = LabMetadata.objects.get(library_id=rglb)
+        # make sure we have recognised sample (e.g. not undetermined)
+        if not lib_metadata:
+            logger.error(f"SKIP CT TSO workflow for {rgsm}_{rglb}. No metadata for {rglb}, this should not happen!")
+            continue
+
+        # skip negative control samples
+        if lib_metadata.phenotype.lower() == LabMetadataPhenotype.N_CONTROL.value.lower():
+            logger.info(f"SKIP CT TSO workflow for '{rgsm}_{rglb}'. Negative-control.")
+            continue
+
+        # Skip samples where metadata workflow is set to manual
+        if lib_metadata.workflow.lower() == LabMetadataWorkflow.MANUAL.value.lower():
+            # We do not pursue manual samples
+            logger.info(f"SKIP CT TSO workflow for '{rgsm}_{rglb}'. Workflow set to manual.")
+            continue
+
+        # skip germline if assay type is not WGS
+        if lib_metadata.type.lower() != LabMetadataType.CT_TSO.value.lower():
+            logger.warning(f"SKIP ctTSO workflow for '{rgsm}_{rglb}'. 'ctTSO' != '{lib_metadata.type}'.")
+            continue
+
+        # convert read_1 and read_2 to cwl file location dict format
+
+        rglb_df["read_1"] = rglb_df["read_1"].apply(lambda x: liborca.cwl_file_path_as_string_to_dict(x))
+        rglb_df["read_2"] = rglb_df["read_2"].apply(lambda x: liborca.cwl_file_path_as_string_to_dict(x))
+
+        job = {
+            "tso500_sample": {
+                "sample_id": f"{samplesheet_sample_id}",  # This must match the sample sheet
+                "sample_name": f"{rgsm}",
+                "sample_type": "DNA",
+                "pair_id": f"{rgsm}"
+            },
+            "fastq_list_rows": rglb_df.to_json(orient="records"),
+            "samplesheet": liborca.cwl_file_path_as_string_to_dict(samplesheet),
+            "run_info_xml": liborca.cwl_file_path_as_string_to_dict(run_info_xml),
+            "run_parameters_xml": liborca.cwl_file_path_as_string_to_dict(run_parameters_xml),
+            "seq_run_id": this_sqr.run_id if this_sqr else None,
+            "seq_name": this_sqr.name if this_sqr else None,
+            "batch_run_id": int(this_batch_run.id)
+        }
+
+        job_list.append(job)
+
+    return job_list
+
+
+def get_ct_tso_samplesheet_from_bcl_convert_output(workflow_output):
+    """
+    Get the gds path containing the samplesheet used for splitting ctTSO samples
+    """
+    samplesheet_locations = [Path(samplesheet.get("location"))
+                             for samplesheet in workflow_output['split_sheets']]
+
+    for samplesheet_location in samplesheet_locations:
+        regex_obj = re.fullmatch(SAMPLESHEET_ASSAY_TYPE_REGEX, samplesheet_location.name)
+        if regex_obj is None:
+            logger.warning(f"Could not get SampleSheet '{samplesheet_location.name}' to fit"
+                           f" into regex '{SAMPLESHEET_ASSAY_TYPE_REGEX}'")
+            continue
+        # Collect midfix of samplesheet
+        assay_type = regex_obj.group(1)
+
+        if assay_type == CTTSO_ASSAY_TYPE:
+            return samplesheet_location
+
+
+def get_run_xml_files_from_bcl_convert_workflow(bcl_convert_input):
+    """
+    From the input object, get the bcl_input_directory directory value and add 'RunInfo.xml' and 'RunParameters.xml'
+    :param bcl_convert_input:
+    :return:
+    """
+
+    bcl_input_dir = bcl_convert_input['bcl_input_directory']['location']
+
+    return Path(bcl_input_dir) / "RunInfo.xml", Path(bcl_input_dir) / "RunParameters.xml"
+
+
+

--- a/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
@@ -11,7 +11,7 @@ import json
 import pandas as pd
 
 from data_portal.models import Batch, BatchRun, SequenceRun, LabMetadata, LabMetadataPhenotype, LabMetadataWorkflow, \
-    LabMetadataType
+    LabMetadataType, LabMetadataAssay
 from data_processors.pipeline.domain.config import SQS_DRAGEN_TSO_CTDNA_QUEUE_ARN
 from data_processors.pipeline.domain.workflow import WorkflowType
 from data_processors.pipeline.lambdas import fastq_list_row
@@ -142,9 +142,11 @@ def prepare_dragen_tso_ctdna_jobs(this_batch: Batch, this_batch_run: BatchRun, t
             logger.info(f"SKIP CT TSO workflow for '{rgsm}_{rglb}'. Workflow set to manual.")
             continue
 
-        # skip germline if assay type is not WGS
-        if lib_metadata.type.lower() != LabMetadataType.CT_TSO.value.lower():
-            logger.warning(f"SKIP ctTSO workflow for '{rgsm}_{rglb}'. 'ctTSO' != '{lib_metadata.type}'.")
+        # skip if assay is not CT_TSO and type is not CT_DNA
+        if not (lib_metadata.type.lower() == LabMetadataType.CT_DNA.value.lower() and
+                lib_metadata.assay.lower() == LabMetadataAssay.CT_TSO.value.lower()):
+            logger.warning(f"SKIP ctTSO workflow for '{rgsm}_{rglb}'. "
+                           f"type: 'ctDNA' != '{lib_metadata.type}' or assay: 'ctTSO' != '{lib_metadata.assay}'")
             continue
 
         # convert read_1 and read_2 to cwl file location dict format

--- a/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
@@ -6,6 +6,7 @@ See orchestration package __init__.py doc string.
 """
 import logging
 from typing import List
+import json
 
 import pandas as pd
 
@@ -176,6 +177,9 @@ def get_ct_tso_samplesheet_from_bcl_convert_output(workflow_output):
     """
     Get the gds path containing the samplesheet used for splitting ctTSO samples
     """
+
+    workflow_output = json.loads(workflow_output)
+
     samplesheet_locations = [Path(samplesheet.get("location"))
                              for samplesheet in workflow_output['split_sheets']]
 
@@ -201,6 +205,8 @@ def get_run_xml_files_from_bcl_convert_workflow(bcl_convert_input):
     :param bcl_convert_input:
     :return:
     """
+
+    bcl_convert_input = json.loads(bcl_convert_input)
 
     bcl_input_dir = bcl_convert_input['bcl_input_directory']['location']
 

--- a/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
@@ -36,7 +36,7 @@ def perform(this_sqr, this_workflow):
     # register a new batch run for this_batch run step
     this_batch_run = batch_srv.skip_or_create_batch_run(
         batch=this_batch,
-        run_step=WorkflowType.CTTSO.value.upper()
+        run_step=WorkflowType.DRAGEN_TSO_CTDNA.value.upper()
     )
     if this_batch_run is None:
         # skip the request if there is on going existing batch_run for the same batch run step

--- a/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
@@ -1,96 +1,61 @@
 # -*- coding: utf-8 -*-
-"""wgs_qc_step module
+"""dragen_tso_ctdna_step module
 
 See domain package __init__.py doc string.
 See orchestration package __init__.py doc string.
 """
-import logging
-from typing import List
 import json
+import logging
+import re
+from pathlib import Path
+from typing import List
 
 import pandas as pd
 
-from data_portal.models import Batch, BatchRun, SequenceRun, LabMetadata, LabMetadataPhenotype, LabMetadataWorkflow, \
-    LabMetadataType, LabMetadataAssay
+from data_portal.models import Workflow, LabMetadata, LabMetadataPhenotype, LabMetadataWorkflow, LabMetadataType, \
+    LabMetadataAssay
+from data_processors.pipeline.domain.batch import Batcher
 from data_processors.pipeline.domain.config import SQS_DRAGEN_TSO_CTDNA_QUEUE_ARN
 from data_processors.pipeline.domain.workflow import WorkflowType
-from data_processors.pipeline.lambdas import fastq_list_row
 from data_processors.pipeline.services import batch_srv, fastq_srv
 from data_processors.pipeline.tools import liborca
 from utils import libssm, libsqs, libjson
-from pathlib import Path
-import re
 
 # GLOBALS
 SAMPLESHEET_ASSAY_TYPE_REGEX = r"^(?:SampleSheet\.)(\S+)(?:\.csv)$"
-CTTSO_ASSAY_TYPE = [ "ctDNA_ctTSO", "ctTSO_ctTSO" ]  # FIXME this will conform to one of these elements at some point.
+CTTSO_ASSAY_TYPE = ["ctDNA_ctTSO", "ctTSO_ctTSO"]  # FIXME this will conform to one of these elements at some point.
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def perform(this_sqr, this_workflow):
-    # create a batch if not exist
-    batch_name = this_sqr.name if this_sqr else f"{this_workflow.type_name}__{this_workflow.wfr_id}"
-    this_batch = batch_srv.get_or_create_batch(name=batch_name, created_by=this_workflow.wfr_id)
+def perform(this_workflow: Workflow):
 
-    # register a new batch run for this_batch run step
-    this_batch_run = batch_srv.skip_or_create_batch_run(
-        batch=this_batch,
-        run_step=WorkflowType.DRAGEN_TSO_CTDNA.value.upper()
+    batcher = Batcher(
+        workflow=this_workflow,
+        run_step=WorkflowType.DRAGEN_TSO_CTDNA.value.upper(),
+        batch_srv=batch_srv,
+        fastq_srv=fastq_srv,
+        logger=logger,
     )
-    if this_batch_run is None:
-        # skip the request if there is on going existing batch_run for the same batch run step
-        # this is especially to fence off duplicate IAP WES events hitting multiple time to our IAP event lambda
-        msg = f"SKIP. THERE IS EXISTING ON GOING RUN FOR BATCH " \
-              f"ID: {this_batch.id}, NAME: {this_batch.name}, CREATED_BY: {this_batch.created_by}"
-        logger.warning(msg)
-        return {'message': msg}
 
-    try:
-        if this_batch.context_data is None:
-            # parse bcl convert output and get all output locations
-            bcl_convert_output_obj = liborca.parse_bcl_convert_output(this_workflow.output)
-            # build a sample info and its related fastq locations
-            fastq_list_rows: List = fastq_list_row.handler({
-                'fastq_list_rows': bcl_convert_output_obj,
-                'seq_name': this_sqr.name,
-            }, None)
+    if batcher.batch_run is None:
+        return batcher.get_skip_message()
 
-            # cache batch context data in db
-            this_batch = batch_srv.update_batch(this_batch.id, context_data=fastq_list_rows)
+    # prepare job list and dispatch to job queue
+    job_list = prepare_dragen_tso_ctdna_jobs(batcher)
+    if job_list:
+        libsqs.dispatch_jobs(
+            queue_arn=libssm.get_ssm_param(SQS_DRAGEN_TSO_CTDNA_QUEUE_ARN),
+            job_list=job_list
+        )
+    else:
+        batcher.reset_batch_run()  # reset running if job_list is empty
 
-            # Initialise fastq list rows object in model
-            for row in fastq_list_rows:
-                fastq_srv.create_or_update_fastq_list_row(row, this_sqr)
-
-        # Get samplesheet and run files from bcl run
-        samplesheet = get_ct_tso_samplesheet_from_bcl_convert_output(this_workflow.output)
-        run_info_xml, run_parameters_xml = get_run_xml_files_from_bcl_convert_workflow(this_workflow.input)
-
-        # prepare job list and dispatch to job queue
-        job_list = prepare_dragen_tso_ctdna_jobs(this_batch, this_batch_run, this_sqr, samplesheet, run_info_xml, run_parameters_xml)
-        if job_list:
-            queue_arn = libssm.get_ssm_param(SQS_DRAGEN_TSO_CTDNA_QUEUE_ARN)
-            libsqs.dispatch_jobs(queue_arn=queue_arn, job_list=job_list)
-        else:
-            batch_srv.reset_batch_run(this_batch_run.id)  # reset running if job_list is empty
-
-    except Exception as e:
-        batch_srv.reset_batch_run(this_batch_run.id)  # reset running
-        raise e
-
-    return {
-        'batch_id': this_batch.id,
-        'batch_name': this_batch.name,
-        'batch_created_by': this_batch.created_by,
-        'batch_run_id': this_batch_run.id,
-        'batch_run_step': this_batch_run.step,
-        'batch_run_status': "RUNNING" if this_batch_run.running else "NOT_RUNNING"
-    }
+    return batcher.get_status()
 
 
-def prepare_dragen_tso_ctdna_jobs(this_batch: Batch, this_batch_run: BatchRun, this_sqr: SequenceRun, samplesheet, run_info_xml, run_parameters_xml) -> List[dict]:
+def prepare_dragen_tso_ctdna_jobs(batcher: Batcher) -> List[dict]:
     """
     NOTE: This launches the cttso cwl workflow that mimics the ISL workflow
     See Example IAP Run > Inputs
@@ -106,53 +71,53 @@ def prepare_dragen_tso_ctdna_jobs(this_batch: Batch, this_batch_run: BatchRun, t
             - all rerun(s)
     This constitute one ctTSO job (i.e. one ctTSO workflow run).
 
-    See OrchestratorIntegrationTests.test_prepare_ct_tso_jobs() for example job list of SEQ-II validation run.
+    See test_prepare_dragen_tso_ctdna_jobs() for example job list of validation run.
 
-    :param this_batch:
-    :param this_batch_run:
-    :param this_sqr:
+    :param batcher:
     :return:
     """
     job_list = []
-    fastq_list_rows: List[dict] = libjson.loads(this_batch.context_data)
+    fastq_list_rows: List[dict] = libjson.loads(batcher.batch.context_data)
 
     # iterate through each sample group by rglb
     for rglb, rglb_df in pd.DataFrame(fastq_list_rows).groupby("rglb"):
         # Check rgsm is identical
         # .item() will raise error if there exists more than one sample name for a given library
         rgsm = rglb_df['rgsm'].unique().item()
-        # Sample ID
-        samplesheet_sample_id = rglb_df['rgid'].apply(lambda x: x.rsplit(".", 1)[-1]).unique().item()
+
         # Get the metadata for the library
         # NOTE: this will use the library base ID (i.e. without topup/rerun extension), as the metadata is the same
         lib_metadata: LabMetadata = LabMetadata.objects.get(library_id=rglb)
         # make sure we have recognised sample (e.g. not undetermined)
         if not lib_metadata:
-            logger.error(f"SKIP CT TSO workflow for {rgsm}_{rglb}. No metadata for {rglb}, this should not happen!")
+            logger.error(f"SKIP DRAGEN_TSO_CTDNA workflow for {rgsm}_{rglb}. "
+                         f"No metadata for {rglb}, this should not happen!")
             continue
 
         # skip negative control samples
         if lib_metadata.phenotype.lower() == LabMetadataPhenotype.N_CONTROL.value.lower():
-            logger.info(f"SKIP CT TSO workflow for '{rgsm}_{rglb}'. Negative-control.")
+            logger.info(f"SKIP DRAGEN_TSO_CTDNA workflow for '{rgsm}_{rglb}'. Negative-control.")
             continue
 
         # Skip samples where metadata workflow is set to manual
         if lib_metadata.workflow.lower() == LabMetadataWorkflow.MANUAL.value.lower():
             # We do not pursue manual samples
-            logger.info(f"SKIP CT TSO workflow for '{rgsm}_{rglb}'. Workflow set to manual.")
+            logger.info(f"SKIP DRAGEN_TSO_CTDNA workflow for '{rgsm}_{rglb}'. Workflow set to manual.")
             continue
 
         # skip if assay is not CT_TSO and type is not CT_DNA
         if not (lib_metadata.type.lower() == LabMetadataType.CT_DNA.value.lower() and
                 lib_metadata.assay.lower() == LabMetadataAssay.CT_TSO.value.lower()):
-            logger.warning(f"SKIP ctTSO workflow for '{rgsm}_{rglb}'. "
-                           f"type: 'ctDNA' != '{lib_metadata.type}' or assay: 'ctTSO' != '{lib_metadata.assay}'")
+            logger.warning(f"SKIP DRAGEN_TSO_CTDNA workflow for '{rgsm}_{rglb}'. "
+                           f"Type: 'ctDNA' != '{lib_metadata.type}' or Assay: 'ctTSO' != '{lib_metadata.assay}'")
             continue
 
-        # convert read_1 and read_2 to cwl file location dict format
+        # Sample ID
+        samplesheet_sample_id = rglb_df['rgid'].apply(lambda x: x.rsplit(".", 1)[-1]).unique().item()
 
-        rglb_df["read_1"] = rglb_df["read_1"].apply(lambda x: liborca.cwl_file_path_as_string_to_dict(x))
-        rglb_df["read_2"] = rglb_df["read_2"].apply(lambda x: liborca.cwl_file_path_as_string_to_dict(x))
+        # Get samplesheet and run files from bcl run
+        samplesheet = get_ct_tso_samplesheet_from_bcl_convert_output(batcher.workflow.output)
+        run_info_xml, run_parameters_xml = get_run_xml_files_from_bcl_convert_workflow(batcher.workflow.input)
 
         job = {
             "tso500_sample": {
@@ -165,9 +130,9 @@ def prepare_dragen_tso_ctdna_jobs(this_batch: Batch, this_batch_run: BatchRun, t
             "samplesheet": liborca.cwl_file_path_as_string_to_dict(samplesheet),
             "run_info_xml": liborca.cwl_file_path_as_string_to_dict(run_info_xml),
             "run_parameters_xml": liborca.cwl_file_path_as_string_to_dict(run_parameters_xml),
-            "seq_run_id": this_sqr.run_id if this_sqr else None,
-            "seq_name": this_sqr.name if this_sqr else None,
-            "batch_run_id": int(this_batch_run.id)
+            "seq_run_id": batcher.sqr.run_id if batcher.sqr else None,
+            "seq_name": batcher.sqr.name if batcher.sqr else None,
+            "batch_run_id": int(batcher.batch_run.id)
         }
 
         job_list.append(job)
@@ -182,13 +147,16 @@ def get_ct_tso_samplesheet_from_bcl_convert_output(workflow_output):
 
     workflow_output = json.loads(workflow_output)
 
-    samplesheet_locations = [Path(samplesheet.get("location"))
-                             for samplesheet in workflow_output['split_sheets']]
+    samplesheet_locations = []
+    for samplesheet in workflow_output['split_sheets']:
+        samplesheet_locations.append(samplesheet['location'])
 
     for samplesheet_location in samplesheet_locations:
-        regex_obj = re.fullmatch(SAMPLESHEET_ASSAY_TYPE_REGEX, samplesheet_location.name)
+        samplesheet_path_obj = Path(samplesheet_location)  # Note Path object is not URI scheme safe, it loose a slash
+        samplesheet_name = samplesheet_path_obj.name
+        regex_obj = re.fullmatch(SAMPLESHEET_ASSAY_TYPE_REGEX, samplesheet_name)
         if regex_obj is None:
-            logger.warning(f"Could not get SampleSheet '{samplesheet_location.name}' to fit"
+            logger.warning(f"Could not get SampleSheet '{samplesheet_name}' to fit"
                            f" into regex '{SAMPLESHEET_ASSAY_TYPE_REGEX}'")
             continue
         # Collect midfix of samplesheet
@@ -212,7 +180,4 @@ def get_run_xml_files_from_bcl_convert_workflow(bcl_convert_input):
 
     bcl_input_dir = bcl_convert_input['bcl_input_directory']['location']
 
-    return str(Path(bcl_input_dir) / "RunInfo.xml"), str(Path(bcl_input_dir) / "RunParameters.xml")
-
-
-
+    return f"{bcl_input_dir}/RunInfo.xml", f"{bcl_input_dir}/RunParameters.xml"

--- a/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
@@ -212,7 +212,7 @@ def get_run_xml_files_from_bcl_convert_workflow(bcl_convert_input):
 
     bcl_input_dir = bcl_convert_input['bcl_input_directory']['location']
 
-    return Path(bcl_input_dir) / "RunInfo.xml", Path(bcl_input_dir) / "RunParameters.xml"
+    return str(Path(bcl_input_dir) / "RunInfo.xml"), str(Path(bcl_input_dir) / "RunParameters.xml")
 
 
 

--- a/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from data_portal.models import Batch, BatchRun, SequenceRun, LabMetadata, LabMetadataPhenotype, LabMetadataWorkflow, \
     LabMetadataType
-from data_processors.pipeline.domain.config import SQS_CT_TSO_QUEUE_ARN
+from data_processors.pipeline.domain.config import SQS_DRAGEN_TSO_CTDNA_QUEUE_ARN
 from data_processors.pipeline.domain.workflow import WorkflowType
 from data_processors.pipeline.lambdas import fastq_list_row
 from data_processors.pipeline.services import batch_srv, fastq_srv
@@ -68,9 +68,9 @@ def perform(this_sqr, this_workflow):
         run_info_xml, run_parameters_xml = get_run_xml_files_from_bcl_convert_workflow(this_workflow.input)
 
         # prepare job list and dispatch to job queue
-        job_list = prepare_ct_tso_jobs(this_batch, this_batch_run, this_sqr, samplesheet, run_info_xml, run_parameters_xml)
+        job_list = prepare_dragen_tso_ctdna_jobs(this_batch, this_batch_run, this_sqr, samplesheet, run_info_xml, run_parameters_xml)
         if job_list:
-            queue_arn = libssm.get_ssm_param(SQS_CT_TSO_QUEUE_ARN)
+            queue_arn = libssm.get_ssm_param(SQS_DRAGEN_TSO_CTDNA_QUEUE_ARN)
             libsqs.dispatch_jobs(queue_arn=queue_arn, job_list=job_list)
         else:
             batch_srv.reset_batch_run(this_batch_run.id)  # reset running if job_list is empty
@@ -89,7 +89,7 @@ def perform(this_sqr, this_workflow):
     }
 
 
-def prepare_ct_tso_jobs(this_batch: Batch, this_batch_run: BatchRun, this_sqr: SequenceRun, samplesheet, run_info_xml, run_parameters_xml) -> List[dict]:
+def prepare_dragen_tso_ctdna_jobs(this_batch: Batch, this_batch_run: BatchRun, this_sqr: SequenceRun, samplesheet, run_info_xml, run_parameters_xml) -> List[dict]:
     """
     NOTE: This launches the cttso cwl workflow that mimics the ISL workflow
     See Example IAP Run > Inputs

--- a/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
@@ -195,7 +195,7 @@ def get_ct_tso_samplesheet_from_bcl_convert_output(workflow_output):
         assay_type = regex_obj.group(1)
 
         if assay_type in CTTSO_ASSAY_TYPE:
-            return samplesheet_location
+            return str(samplesheet_location)
 
     logger.warning("Did not get a ct tso samplesheet from the bclconvert output")
     return None

--- a/data_processors/pipeline/orchestration/dragen_wgs_qc_step.py
+++ b/data_processors/pipeline/orchestration/dragen_wgs_qc_step.py
@@ -9,76 +9,44 @@ from typing import List
 
 import pandas as pd
 
-from data_portal.models import Batch, BatchRun, SequenceRun, LabMetadata, LabMetadataPhenotype, LabMetadataWorkflow, \
-    LabMetadataType
+from data_portal.models import LabMetadata, LabMetadataPhenotype, LabMetadataWorkflow, LabMetadataType, Workflow
+from data_processors.pipeline.domain.batch import Batcher
 from data_processors.pipeline.domain.config import SQS_DRAGEN_WGS_QC_QUEUE_ARN
 from data_processors.pipeline.domain.workflow import WorkflowType
-from data_processors.pipeline.lambdas import fastq_list_row
 from data_processors.pipeline.services import batch_srv, fastq_srv
-from data_processors.pipeline.tools import liborca
 from utils import libssm, libsqs, libjson
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def perform(this_sqr, this_workflow):
-    # create a batch if not exist
-    batch_name = this_sqr.name if this_sqr else f"{this_workflow.type_name}__{this_workflow.wfr_id}"
-    this_batch = batch_srv.get_or_create_batch(name=batch_name, created_by=this_workflow.wfr_id)
+def perform(this_workflow: Workflow):
 
-    # register a new batch run for this_batch run step
-    this_batch_run = batch_srv.skip_or_create_batch_run(
-        batch=this_batch,
-        run_step=WorkflowType.DRAGEN_WGS_QC.value.upper()
+    batcher = Batcher(
+        workflow=this_workflow,
+        run_step=WorkflowType.DRAGEN_WGS_QC.value.upper(),
+        batch_srv=batch_srv,
+        fastq_srv=fastq_srv,
+        logger=logger,
     )
-    if this_batch_run is None:
-        # skip the request if there is on going existing batch_run for the same batch run step
-        # this is especially to fence off duplicate IAP WES events hitting multiple time to our IAP event lambda
-        msg = f"SKIP. THERE IS EXISTING ON GOING RUN FOR BATCH " \
-              f"ID: {this_batch.id}, NAME: {this_batch.name}, CREATED_BY: {this_batch.created_by}"
-        logger.warning(msg)
-        return {'message': msg}
 
-    try:
-        if this_batch.context_data is None:
-            # parse bcl convert output and get all output locations
-            # build a sample info and its related fastq locations
-            fastq_list_rows: List = fastq_list_row.handler({
-                'fastq_list_rows': liborca.parse_bcl_convert_output(this_workflow.output),
-                'seq_name': this_sqr.name,
-            }, None)
+    if batcher.batch_run is None:
+        return batcher.get_skip_message()
 
-            # cache batch context data in db
-            this_batch = batch_srv.update_batch(this_batch.id, context_data=fastq_list_rows)
+    # prepare job list and dispatch to job queue
+    job_list = prepare_dragen_wgs_qc_jobs(batcher)
+    if job_list:
+        libsqs.dispatch_jobs(
+            queue_arn=libssm.get_ssm_param(SQS_DRAGEN_WGS_QC_QUEUE_ARN),
+            job_list=job_list
+        )
+    else:
+        batcher.reset_batch_run()  # reset running if job_list is empty
 
-            # Initialise fastq list rows object in model
-            for row in fastq_list_rows:
-                fastq_srv.create_or_update_fastq_list_row(row, this_sqr)
-
-        # prepare job list and dispatch to job queue
-        job_list = prepare_dragen_wgs_qc_jobs(this_batch, this_batch_run, this_sqr)
-        if job_list:
-            queue_arn = libssm.get_ssm_param(SQS_DRAGEN_WGS_QC_QUEUE_ARN)
-            libsqs.dispatch_jobs(queue_arn=queue_arn, job_list=job_list)
-        else:
-            batch_srv.reset_batch_run(this_batch_run.id)  # reset running if job_list is empty
-
-    except Exception as e:
-        batch_srv.reset_batch_run(this_batch_run.id)  # reset running
-        raise e
-
-    return {
-        'batch_id': this_batch.id,
-        'batch_name': this_batch.name,
-        'batch_created_by': this_batch.created_by,
-        'batch_run_id': this_batch_run.id,
-        'batch_run_step': this_batch_run.step,
-        'batch_run_status': "RUNNING" if this_batch_run.running else "NOT_RUNNING"
-    }
+    return batcher.get_status()
 
 
-def prepare_dragen_wgs_qc_jobs(this_batch: Batch, this_batch_run: BatchRun, this_sqr: SequenceRun) -> List[dict]:
+def prepare_dragen_wgs_qc_jobs(batcher: Batcher) -> List[dict]:
     """
     NOTE: as of DRAGEN_WGS_QC CWL workflow version 3.7.5--1.3.5, it uses fastq_list_rows format
     See Example IAP Run > Inputs
@@ -96,19 +64,18 @@ def prepare_dragen_wgs_qc_jobs(this_batch: Batch, this_batch_run: BatchRun, this
 
     See test_prepare_dragen_wgs_qc_jobs() integration test for example job list of SEQ-II validation run.
 
-    :param this_batch:
-    :param this_batch_run:
-    :param this_sqr:
+    :param batcher:
     :return:
     """
     job_list = []
-    fastq_list_rows: List[dict] = libjson.loads(this_batch.context_data)
+    fastq_list_rows: List[dict] = libjson.loads(batcher.batch.context_data)
 
     # iterate through each sample group by rglb
     for rglb, rglb_df in pd.DataFrame(fastq_list_rows).groupby("rglb"):
         # Check rgsm is identical
         # .item() will raise error if there exists more than one sample name for a given library
         rgsm = rglb_df['rgsm'].unique().item()
+
         # Get the metadata for the library
         # NOTE: this will use the library base ID (i.e. without topup/rerun extension), as the metadata is the same
         lib_metadata: LabMetadata = LabMetadata.objects.get(library_id=rglb)
@@ -135,17 +102,12 @@ def prepare_dragen_wgs_qc_jobs(this_batch: Batch, this_batch_run: BatchRun, this
             logger.warning(f"SKIP DRAGEN_WGS_QC workflow for '{rgsm}_{rglb}'. 'WGS' != '{lib_metadata.type}'.")
             continue
 
-        # convert read_1 and read_2 to cwl file location dict format
-
-        rglb_df["read_1"] = rglb_df["read_1"].apply(lambda x: liborca.cwl_file_path_as_string_to_dict(x))
-        rglb_df["read_2"] = rglb_df["read_2"].apply(lambda x: liborca.cwl_file_path_as_string_to_dict(x))
-
         job = {
             "sample_name": f"{rgsm}_{rglb}",
             "fastq_list_rows": rglb_df.to_json(orient="records"),
-            "seq_run_id": this_sqr.run_id if this_sqr else None,
-            "seq_name": this_sqr.name if this_sqr else None,
-            "batch_run_id": int(this_batch_run.id)
+            "seq_run_id": batcher.sqr.run_id if batcher.sqr else None,
+            "seq_name": batcher.sqr.name if batcher.sqr else None,
+            "batch_run_id": int(batcher.batch_run.id)
         }
 
         job_list.append(job)

--- a/data_processors/pipeline/orchestration/fastq_update_step.py
+++ b/data_processors/pipeline/orchestration/fastq_update_step.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from data_portal.models import Workflow
+from data_processors.pipeline.lambdas import fastq_list_row
+from data_processors.pipeline.services import fastq_srv
+from data_processors.pipeline.tools import liborca
+
+
+def perform(this_workflow: Workflow):
+    this_sqr = this_workflow.sequence_run
+
+    # parse bcl convert output and get all output locations
+    # build a sample info and its related fastq locations
+    fastq_list_rows: List = fastq_list_row.handler({
+        'fastq_list_rows': liborca.parse_bcl_convert_output(this_workflow.output),
+        'seq_name': this_sqr.name,
+    }, None)
+
+    # Initialise fastq list rows object in model
+    for row in fastq_list_rows:
+        fastq_srv.create_or_update_fastq_list_row(row, this_sqr)
+
+    return fastq_list_rows

--- a/data_processors/pipeline/orchestration/tests/test_dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_tso_ctdna_step.py
@@ -6,18 +6,63 @@ from django.utils.timezone import make_aware
 from libica.openapi import libwes
 from mockito import when
 
-from data_portal.models import Batch, BatchRun, SequenceRun, Workflow, LabMetadata, LabMetadataPhenotype, \
-    LabMetadataType, LabMetadataAssay
+from data_portal.models import Batch, BatchRun, Workflow, LabMetadata, LabMetadataPhenotype, LabMetadataType, \
+    LabMetadataAssay
 from data_portal.tests.factories import WorkflowFactory, TestConstant
-from data_processors.pipeline.domain.workflow import WorkflowStatus
-from data_processors.pipeline.lambdas import wes_handler, fastq_list_row, orchestrator
-from data_processors.pipeline.orchestration import dragen_tso_ctdna_step
+from data_processors.pipeline.domain.batch import Batcher
+from data_processors.pipeline.domain.workflow import WorkflowStatus, WorkflowType
+from data_processors.pipeline.lambdas import orchestrator
+from data_processors.pipeline.orchestration import fastq_update_step, dragen_tso_ctdna_step
+from data_processors.pipeline.services import batch_srv, fastq_srv
 from data_processors.pipeline.tests.case import PipelineIntegrationTestCase, PipelineUnitTestCase, logger
+from utils import wes
 
 tn_mock_subject_id = "SBJ00001"
 mock_library_id = "LPRJ200438"
 mock_sample_id = "PRJ200438"
 mock_sample_name = f"{mock_sample_id}_{mock_library_id}"
+
+
+def _mock_bcl_convert_output():
+    return {
+        "fastq_list_rows": [
+            {
+                "rgid": "CATGCGAT.4",
+                "rglb": "UnknownLibrary",
+                "rgsm": mock_sample_name,
+                "lane": 4,
+                "read_1": {
+                    "class": "File",
+                    "basename": f"{mock_sample_name}_S1_L004_R1_001.fastq.gz",
+                    "location": f"gds://fastqvol/bcl-convert-test/outputs/10X/{mock_sample_name}_S1_L004_R1_001.fastq.gz",
+                    "nameroot": f"{mock_sample_name}_S1_L004_R1_001.fastq",
+                    "nameext": ".gz",
+                    "http://commonwl.org/cwltool#generation": 0,
+                    "size": 16698849950
+                },
+                "read_2": {
+                    "class": "File",
+                    "basename": f"{mock_sample_name}_S1_L004_R2_001.fastq.gz",
+                    "location": f"gds://fastqvol/bcl-convert-test/outputs/10X/{mock_sample_name}_S1_L004_R2_001.fastq.gz",
+                    "nameroot": f"{mock_sample_name}_S1_L004_R2_001.fastq",
+                    "nameext": ".gz",
+                    "http://commonwl.org/cwltool#generation": 0,
+                    "size": 38716143739
+                }
+            }
+        ],
+        "split_sheets": [
+            {
+                "location": "gds://umccr-fastq-data-prod/210701_A01052_0055_AH7KWGDSX2/SampleSheet.ctDNA_ctTSO.csv",
+                "basename": "SampleSheet.ctDNA_ctTSO.csv",
+                "nameroot": "SampleSheet.ctDNA_ctTSO",
+                "nameext": ".csv",
+                "class": "File",
+                "size": 1804,
+                "http://commonwl.org/cwltool#generation": 0
+            }
+        ]
+    }
 
 
 class DragenTsoCtDnaStepUnitTests(PipelineUnitTestCase):
@@ -39,49 +84,12 @@ class DragenTsoCtDnaStepUnitTests(PipelineUnitTestCase):
             }
         })
         mock_bcl_workflow.save()
+
         mock_wfl_run = libwes.WorkflowRun()
         mock_wfl_run.id = TestConstant.wfr_id.value
         mock_wfl_run.status = WorkflowStatus.SUCCEEDED.value
         mock_wfl_run.time_stopped = make_aware(datetime.utcnow())
-        mock_wfl_run.output = {
-            "fastq_list_rows": [
-                {
-                    "rgid": "CATGCGAT.4",
-                    "rglb": "UnknownLibrary",
-                    "rgsm": mock_sample_name,
-                    "lane": 4,
-                    "read_1": {
-                        "class": "File",
-                        "basename": f"{mock_sample_name}_S1_L004_R1_001.fastq.gz",
-                        "location": f"gds://fastqvol/bcl-convert-test/outputs/10X/{mock_sample_name}_S1_L004_R1_001.fastq.gz",
-                        "nameroot": f"{mock_sample_name}_S1_L004_R1_001.fastq",
-                        "nameext": ".gz",
-                        "http://commonwl.org/cwltool#generation": 0,
-                        "size": 16698849950
-                    },
-                    "read_2": {
-                        "class": "File",
-                        "basename": f"{mock_sample_name}_S1_L004_R2_001.fastq.gz",
-                        "location": f"gds://fastqvol/bcl-convert-test/outputs/10X/{mock_sample_name}_S1_L004_R2_001.fastq.gz",
-                        "nameroot": f"{mock_sample_name}_S1_L004_R2_001.fastq",
-                        "nameext": ".gz",
-                        "http://commonwl.org/cwltool#generation": 0,
-                        "size": 38716143739
-                    }
-                }
-            ],
-            "split_sheets": [
-                              {
-                                "location": "gds://umccr-fastq-data-prod/210701_A01052_0055_AH7KWGDSX2/SampleSheet.ctDNA_ctTSO.csv",
-                                "basename": "SampleSheet.ctDNA_ctTSO.csv",
-                                "nameroot": "SampleSheet.ctDNA_ctTSO",
-                                "nameext": ".csv",
-                                "class": "File",
-                                "size": 1804,
-                                "http://commonwl.org/cwltool#generation": 0
-                              }
-            ]
-        }
+        mock_wfl_run.output = _mock_bcl_convert_output()
 
         workflow_version: libwes.WorkflowVersion = libwes.WorkflowVersion()
         workflow_version.id = TestConstant.wfv_id.value
@@ -110,9 +118,8 @@ class DragenTsoCtDnaStepUnitTests(PipelineUnitTestCase):
             logger.info(f"BATCH: {b}")
         for br in BatchRun.objects.all():
             logger.info(f"BATCH_RUN: {br}")
-        tso_ctdna_batch_runs = [batchrun
-                                for batchrun in BatchRun.objects.all()
-                                if batchrun.step == "DRAGEN_TSO_CTDNA"]
+
+        tso_ctdna_batch_runs = [br for br in BatchRun.objects.all() if br.step == WorkflowType.DRAGEN_TSO_CTDNA.name]
         self.assertTrue(tso_ctdna_batch_runs[0].running)
 
     def test_dragen_tso_ctdna_none(self):
@@ -145,6 +152,33 @@ class DragenTsoCtDnaStepUnitTests(PipelineUnitTestCase):
             logger.exception(f"THIS ERROR EXCEPTION IS INTENTIONAL FOR TEST. NOT ACTUAL ERROR. \n{e}")
         self.assertRaises(json.JSONDecodeError)
 
+    def test_get_ct_tso_samplesheet_from_bcl_convert_output(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_tso_ctdna_step.DragenTsoCtDnaStepUnitTests.test_get_ct_tso_samplesheet_from_bcl_convert_output
+        """
+        mock_bcl_convert_output_json_str = json.dumps(_mock_bcl_convert_output())
+        ss = dragen_tso_ctdna_step.get_ct_tso_samplesheet_from_bcl_convert_output(mock_bcl_convert_output_json_str)
+        logger.info(ss)
+        self.assertTrue(ss.startswith('gds://'))
+        self.assertTrue(ss.endswith('.csv'))
+
+    def test_get_run_xml_files_from_bcl_convert_workflow(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_tso_ctdna_step.DragenTsoCtDnaStepUnitTests.test_get_run_xml_files_from_bcl_convert_workflow
+        """
+        mock_bcl_convert_input = json.dumps({
+            'bcl_input_directory': {
+                "class": "Directory",
+                "location": "gds://bssh-path/Runs/210701_A01052_0055_AH7KWGDSX2_r.abc123456"
+            }
+        })
+
+        xml_files = dragen_tso_ctdna_step.get_run_xml_files_from_bcl_convert_workflow(mock_bcl_convert_input)
+        for file in xml_files:
+            logger.info(file)
+            self.assertTrue(file.startswith('gds://'))
+            self.assertTrue(file.endswith('.xml'))
+
 
 class DragenTsoCtDnaStepIntegrationTests(PipelineIntegrationTestCase):
     # integration test hit actual File or API endpoint, thus, manual run in most cases
@@ -158,68 +192,61 @@ class DragenTsoCtDnaStepIntegrationTests(PipelineIntegrationTestCase):
         python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_tso_ctdna_step.DragenTsoCtDnaStepIntegrationTests.test_prepare_dragen_tso_ctdna_jobs
         """
 
-        # --- Setup these values
+        # --- pick one successful BCL Convert run in development project
 
-        bssh_run_id = "r.Uvlx2DEIME-KH0BRyF9XBg"
-        bssh_run_name = "200612_A01052_0017_BH5LYWDSXY"
-        bssh_run_path = "/200612_A01052_0017_BH5LYWDSXY_r.Uvlx2DEIME-KH0BRyF9XBg"
-        bssh_run_volume = "umccr-raw-sequence-data-dev"
-        bssh_samplesheet_name = "SampleSheet.csv"
-        bcl_convert_wfr_id = "wfr.81cf25d7226a4874be43e4b15c1f5687"
+        # FIXME required to switch PROD `export AWS_PROFILE=prod` as no validation run data avail in DEV yet
+        #   use `ica workflows runs get wfr.xxx` to see run details
+        bcl_convert_wfr_id = "wfr.41eda23e48a04cdca71b2875686c2439"
+        total_jobs_to_eval = 15
 
-        # --- Get pipeline state
+        # --- we need to rewind & replay pipeline state in the test db (like cassette tape, ya know!)
 
-        bcl_convert_run = wes_handler.get_workflow_run({'wfr_id': bcl_convert_wfr_id}, None)
+        # first --
+        # - we need metadata!
+        # - populate LabMetadata tables in test db
+        from data_processors.lims.lambdas import labmetadata
+        labmetadata.scheduled_update_handler({'sheet': "2020"}, None)
+        labmetadata.scheduled_update_handler({'sheet': "2021"}, None)
+        logger.info(f"Lab metadata count: {LabMetadata.objects.count()}")
 
-        print('-' * 32)
+        # second --
+        # - we need to have BCL Convert workflow in db
+        # - WorkflowFactory also create related fixture sub factory SequenceRunFactory and linked them
+        mock_bcl_convert: Workflow = WorkflowFactory()
 
-        fastq_list = fastq_list_row.handler({
-            'fastq_list_rows': bcl_convert_run['output']['fastq_list_rows'],
-            'seq_name': bssh_run_name
-        }, None)
+        # third --
+        # - grab workflow run from WES endpoint
+        # - sync input and output attributes to our mock BCL Convert workflow in db
+        bcl_convert_run = wes.get_run(bcl_convert_wfr_id, to_dict=True)
+        mock_bcl_convert.input = json.dumps(bcl_convert_run['input'])
+        mock_bcl_convert.output = json.dumps(bcl_convert_run['output'])
+        mock_bcl_convert.save()
 
-        # --- Make mock pipeline state in test db
+        # fourth --
+        # - replay FastqListRow update step after BCL Convert workflow succeeded
+        fastq_update_step.perform(mock_bcl_convert)
 
-        mock_batch = Batch(name="Test", created_by="Test", context_data=json.dumps(fastq_list))
-        mock_batch.save()
-
-        mock_batch_run = BatchRun(batch=mock_batch, step="Test")
-        mock_batch_run.save()
-
-        mock_sqr_run = SequenceRun(
-            run_id=bssh_run_id,
-            date_modified=make_aware(datetime.utcnow()),
-            status="PendingAnalysis",
-            instrument_run_id=bssh_run_name,
-            gds_folder_path=bssh_run_path,
-            gds_volume_name=bssh_run_volume,
-            reagent_barcode="NV9999999-RGSBS",
-            v1pre3_id="666666",
-            acl=["wid:acgtacgt-9999-38ed-99fa-94fe79523959"],
-            flowcell_barcode="BARCODEEE",
-            sample_sheet_name=bssh_samplesheet_name,
-            api_url=f"https://ilmn/v2/runs/r.ACGTlKjDgEy099ioQOeOWg",
-            name=bssh_run_name,
-            msg_attr_action="statuschanged",
-            msg_attr_action_type="bssh.runs",
-            msg_attr_action_date="2020-05-09T22:17:10.815Z",
-            msg_attr_produced_by="BaseSpaceSequenceHub"
+        # fifth --
+        # - we also need Batch and BatchRun since DRAGEN_WGS_QC workflows (jobs) are running in batch manner
+        # - we will use Batcher to create them, just like in dragen_wgs_qc_step.perform()
+        batcher = Batcher(
+            workflow=mock_bcl_convert,
+            run_step=WorkflowType.DRAGEN_TSO_CTDNA.value.upper(),
+            batch_srv=batch_srv,
+            fastq_srv=fastq_srv,
+            logger=logger
         )
-        mock_sqr_run.save()
 
         print('-'*32)
         logger.info("PREPARE DRAGEN_TSO_CTDNA JOBS:")
 
-        job_list = dragen_tso_ctdna_step.prepare_dragen_tso_ctdna_jobs(
-            this_batch=mock_batch,
-            this_batch_run=mock_batch_run,
-            this_sqr=mock_sqr_run,
-        )
+        job_list = dragen_tso_ctdna_step.prepare_dragen_tso_ctdna_jobs(batcher)
 
         print('-'*32)
         logger.info("JOB LIST JSON:")
         print()
         print(json.dumps(job_list))
         print()
+        logger.info("YOU SHOULD COPY ABOVE JSON INTO A FILE, FORMAT IT AND CHECK THAT IT LOOKS ALRIGHT")
         self.assertIsNotNone(job_list)
-        self.assertEqual(len(job_list), 8)
+        self.assertEqual(len(job_list), total_jobs_to_eval)

--- a/data_processors/pipeline/orchestration/tests/test_dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_tso_ctdna_step.py
@@ -1,0 +1,204 @@
+import json
+from datetime import datetime
+from unittest import skip
+
+from django.utils.timezone import make_aware
+from libica.openapi import libwes
+from mockito import when
+
+from data_portal.models import Batch, BatchRun, SequenceRun, Workflow, LabMetadata, LabMetadataPhenotype, \
+    LabMetadataType
+from data_portal.tests.factories import WorkflowFactory, TestConstant
+from data_processors.pipeline.domain.workflow import WorkflowStatus
+from data_processors.pipeline.lambdas import wes_handler, fastq_list_row, orchestrator
+from data_processors.pipeline.orchestration import dragen_tso_ctdna_step
+from data_processors.pipeline.tests.case import PipelineIntegrationTestCase, PipelineUnitTestCase, logger
+
+tn_mock_subject_id = "SBJ00001"
+mock_library_id = "LPRJ200438"
+mock_sample_id = "PRJ200438"
+mock_sample_name = f"{mock_sample_id}_{mock_library_id}"
+
+
+class DragenTsoCtDnaStepUnitTests(PipelineUnitTestCase):
+
+    def setUp(self) -> None:
+        super(DragenTsoCtDnaStepUnitTests, self).setUp()
+
+    def test_dragen_tso_ctdna(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_tso_ctdna_step.DragenTsoCtDnaStepUnitTests.test_dragen_tso_ctdna
+        """
+        self.verify_local()
+
+        mock_bcl_workflow: Workflow = WorkflowFactory()
+
+        mock_wfl_run = libwes.WorkflowRun()
+        mock_wfl_run.id = TestConstant.wfr_id.value
+        mock_wfl_run.status = WorkflowStatus.SUCCEEDED.value
+        mock_wfl_run.time_stopped = make_aware(datetime.utcnow())
+        mock_wfl_run.output = {
+            "main/fastq_list_rows": [
+                {
+                    "rgid": "CATGCGAT.4",
+                    "rglb": "UnknownLibrary",
+                    "rgsm": mock_sample_name,
+                    "lane": 4,
+                    "read_1": {
+                        "class": "File",
+                        "basename": f"{mock_sample_name}_S1_L004_R1_001.fastq.gz",
+                        "location": f"gds://fastqvol/bcl-convert-test/outputs/10X/{mock_sample_name}_S1_L004_R1_001.fastq.gz",
+                        "nameroot": f"{mock_sample_name}_S1_L004_R1_001.fastq",
+                        "nameext": ".gz",
+                        "http://commonwl.org/cwltool#generation": 0,
+                        "size": 16698849950
+                    },
+                    "read_2": {
+                        "class": "File",
+                        "basename": f"{mock_sample_name}_S1_L004_R2_001.fastq.gz",
+                        "location": f"gds://fastqvol/bcl-convert-test/outputs/10X/{mock_sample_name}_S1_L004_R2_001.fastq.gz",
+                        "nameroot": f"{mock_sample_name}_S1_L004_R2_001.fastq",
+                        "nameext": ".gz",
+                        "http://commonwl.org/cwltool#generation": 0,
+                        "size": 38716143739
+                    }
+                }
+            ]
+        }
+
+        workflow_version: libwes.WorkflowVersion = libwes.WorkflowVersion()
+        workflow_version.id = TestConstant.wfv_id.value
+        mock_wfl_run.workflow_version = workflow_version
+        when(libwes.WorkflowRunsApi).get_workflow_run(...).thenReturn(mock_wfl_run)
+
+        #LPRJ200438
+        mock_labmetadata_tumor = LabMetadata()
+        mock_labmetadata_tumor.subject_id = tn_mock_subject_id
+        mock_labmetadata_tumor.library_id = mock_library_id
+        mock_labmetadata_tumor.phenotype = LabMetadataPhenotype.TUMOR.value
+        mock_labmetadata_tumor.type = LabMetadataType.CT_DNA.value
+        mock_labmetadata_tumor.save()
+
+        result = orchestrator.handler({
+            'wfr_id': TestConstant.wfr_id.value,
+            'wfv_id': TestConstant.wfv_id.value,
+        }, None)
+
+        logger.info("-" * 32)
+        self.assertIsNotNone(result)
+        logger.info(f"Orchestrator lambda call output: \n{json.dumps(result)}")
+
+        for b in Batch.objects.all():
+            logger.info(f"BATCH: {b}")
+        for br in BatchRun.objects.all():
+            logger.info(f"BATCH_RUN: {br}")
+        self.assertTrue(BatchRun.objects.all()[0].running)
+
+    def test_dragen_tso_ctdna_none(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_tso_ctdna_step.DragenTsoCtDnaStepUnitTests.test_dragen_tso_ctdna_none
+
+        Similar to ^^ test case but BCL Convert output is None
+        """
+        self.verify_local()
+
+        mock_bcl_workflow: Workflow = WorkflowFactory()
+
+        mock_wfl_run = libwes.WorkflowRun()
+        mock_wfl_run.id = TestConstant.wfr_id.value
+        mock_wfl_run.status = WorkflowStatus.SUCCEEDED.value
+        mock_wfl_run.time_stopped = make_aware(datetime.utcnow())
+        mock_wfl_run.output = None  # mock output is NONE while status is SUCCEEDED
+
+        workflow_version: libwes.WorkflowVersion = libwes.WorkflowVersion()
+        workflow_version.id = TestConstant.wfv_id.value
+        mock_wfl_run.workflow_version = workflow_version
+        when(libwes.WorkflowRunsApi).get_workflow_run(...).thenReturn(mock_wfl_run)
+
+        try:
+            orchestrator.handler({
+                'wfr_id': TestConstant.wfr_id.value,
+                'wfv_id': TestConstant.wfv_id.value,
+            }, None)
+        except Exception as e:
+            logger.exception(f"THIS ERROR EXCEPTION IS INTENTIONAL FOR TEST. NOT ACTUAL ERROR. \n{e}")
+        self.assertRaises(json.JSONDecodeError)
+
+
+class DragenTsoCtDnaStepIntegrationTests(PipelineIntegrationTestCase):
+    # integration test hit actual File or API endpoint, thus, manual run in most cases
+    # required appropriate access mechanism setup such as active aws login session
+    # uncomment @skip and hit the each test case!
+    # and keep decorated @skip after tested
+
+    @skip
+    def test_prepare_dragen_tso_ctdna_jobs(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_tso_ctdna_step.DragenTsoCtDnaStepUnitTests.test_prepare_dragen_tso_ctdna_jobs
+        """
+
+        # --- Setup these values
+
+        bssh_run_id = "r.Uvlx2DEIME-KH0BRyF9XBg"
+        bssh_run_name = "200612_A01052_0017_BH5LYWDSXY"
+        bssh_run_path = "/200612_A01052_0017_BH5LYWDSXY_r.Uvlx2DEIME-KH0BRyF9XBg"
+        bssh_run_volume = "umccr-raw-sequence-data-dev"
+        bssh_samplesheet_name = "SampleSheet.csv"
+        bcl_convert_wfr_id = "wfr.81cf25d7226a4874be43e4b15c1f5687"
+
+        # --- Get pipeline state
+
+        bcl_convert_run = wes_handler.get_workflow_run({'wfr_id': bcl_convert_wfr_id}, None)
+
+        print('-' * 32)
+
+        fastq_list = fastq_list_row.handler({
+            'fastq_list_rows': bcl_convert_run['output']['fastq_list_rows'],
+            'seq_name': bssh_run_name
+        }, None)
+
+        # --- Make mock pipeline state in test db
+
+        mock_batch = Batch(name="Test", created_by="Test", context_data=json.dumps(fastq_list))
+        mock_batch.save()
+
+        mock_batch_run = BatchRun(batch=mock_batch, step="Test")
+        mock_batch_run.save()
+
+        mock_sqr_run = SequenceRun(
+            run_id=bssh_run_id,
+            date_modified=make_aware(datetime.utcnow()),
+            status="PendingAnalysis",
+            instrument_run_id=bssh_run_name,
+            gds_folder_path=bssh_run_path,
+            gds_volume_name=bssh_run_volume,
+            reagent_barcode="NV9999999-RGSBS",
+            v1pre3_id="666666",
+            acl=["wid:acgtacgt-9999-38ed-99fa-94fe79523959"],
+            flowcell_barcode="BARCODEEE",
+            sample_sheet_name=bssh_samplesheet_name,
+            api_url=f"https://ilmn/v2/runs/r.ACGTlKjDgEy099ioQOeOWg",
+            name=bssh_run_name,
+            msg_attr_action="statuschanged",
+            msg_attr_action_type="bssh.runs",
+            msg_attr_action_date="2020-05-09T22:17:10.815Z",
+            msg_attr_produced_by="BaseSpaceSequenceHub"
+        )
+        mock_sqr_run.save()
+
+        print('-'*32)
+        logger.info("PREPARE DRAGEN_TSO_CTDNA JOBS:")
+
+        job_list = dragen_tso_ctdna_step.prepare_dragen_tso_ctdna_jobs(
+            this_batch=mock_batch,
+            this_batch_run=mock_batch_run,
+            this_sqr=mock_sqr_run,
+        )
+
+        print('-'*32)
+        logger.info("JOB LIST JSON:")
+        print()
+        print(json.dumps(job_list))
+        print()
+        self.assertIsNotNone(job_list)
+        self.assertEqual(len(job_list), 8)

--- a/data_processors/pipeline/orchestration/tests/test_dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_tso_ctdna_step.py
@@ -110,7 +110,10 @@ class DragenTsoCtDnaStepUnitTests(PipelineUnitTestCase):
             logger.info(f"BATCH: {b}")
         for br in BatchRun.objects.all():
             logger.info(f"BATCH_RUN: {br}")
-        self.assertTrue(BatchRun.objects.all()[0].running)
+        tso_ctdna_batch_runs = [batchrun
+                                for batchrun in BatchRun.objects.all()
+                                if batchrun.step == "DRAGEN_TSO_CTDNA"]
+        self.assertTrue(tso_ctdna_batch_runs[0].running)
 
     def test_dragen_tso_ctdna_none(self):
         """
@@ -152,7 +155,7 @@ class DragenTsoCtDnaStepIntegrationTests(PipelineIntegrationTestCase):
     @skip
     def test_prepare_dragen_tso_ctdna_jobs(self):
         """
-        python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_tso_ctdna_step.DragenTsoCtDnaStepUnitTests.test_prepare_dragen_tso_ctdna_jobs
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_tso_ctdna_step.DragenTsoCtDnaStepIntegrationTests.test_prepare_dragen_tso_ctdna_jobs
         """
 
         # --- Setup these values

--- a/data_processors/pipeline/services/fastq_srv.py
+++ b/data_processors/pipeline/services/fastq_srv.py
@@ -64,6 +64,17 @@ def create_or_update_fastq_list_row(fastq_list_row: dict, sequence_run: Sequence
 
 
 @transaction.atomic
+def get_fastq_list_row_by_sequence_name(sequence_name):
+    qs = FastqListRow.objects.filter(sequence_run__name__iexact=sequence_name)
+    if qs.exists():
+        fqlr_list = []
+        for fqlr in qs.all():
+            fqlr_list.append(fqlr.to_dict())
+        return fqlr_list
+    return None
+
+
+@transaction.atomic
 def get_fastq_list_row_by_rgid(rgid):
     try:
         fastq_list_row = FastqListRow.objects.get(rgid=rgid)

--- a/data_processors/pipeline/tools/liborca.py
+++ b/data_processors/pipeline/tools/liborca.py
@@ -54,6 +54,15 @@ def cwl_file_path_as_string_to_dict(file_path):
     return {"class": "File", "location": file_path}
 
 
+def cwl_dir_path_as_string_to_dict(dir_path):
+    """
+    Convert "gds://path/to/dir to {"class": "Directory", "location": "gds://path/to/file"}
+    :param dir_path:
+    :return:
+    """
+    return {"class": "Directory", "location": dir_path}
+
+
 def get_run_number_from_run_name(run_name: str) -> int:
     return int(run_name.split('_')[2])
 

--- a/loaddata.sh
+++ b/loaddata.sh
@@ -96,6 +96,10 @@ load_localstack() {
   sqs_dragen_wgs_qc_queue_name=${sqs_dragen_wgs_qc_queue_arn##*:}
   eval "$aws_local_cmd sqs create-queue --queue-name $sqs_dragen_wgs_qc_queue_name --attributes FifoQueue=true,ContentBasedDeduplication=true"
 
+  sqs_dragen_tso_ctdna_queue_arn=$(aws ssm get-parameter --name '/data_portal/backend/sqs_dragen_tso_ctdna_queue_arn' --with-decryption | jq -r .Parameter.Value)
+  sqs_dragen_tso_ctdna_queue_name=${sqs_dragen_tso_ctdna_queue_arn##*:}
+  eval "$aws_local_cmd sqs create-queue --queue-name $sqs_dragen_tso_ctdna_queue_name --attributes FifoQueue=true,ContentBasedDeduplication=true"
+
   sqs_tumor_normal_queue_arn=$(aws ssm get-parameter --name '/data_portal/backend/sqs_tumor_normal_queue_arn' --with-decryption | jq -r .Parameter.Value)
   sqs_tumor_normal_queue_name=${sqs_tumor_normal_queue_arn##*:}
   eval "$aws_local_cmd sqs create-queue --queue-name $sqs_tumor_normal_queue_name --attributes FifoQueue=true,ContentBasedDeduplication=true"

--- a/serverless.yml
+++ b/serverless.yml
@@ -154,6 +154,15 @@ functions:
           arn: ${ssm:/data_portal/backend/sqs_dragen_wgs_qc_queue_arn}
     timeout: 28
 
+  sqs_dragen_tso_ctdna_event_processor:
+    handler: data_processors.pipeline.lambdas.dragen_tso_ctdna.sqs_handler
+    layers:
+      - { Ref: PythonRequirementsLambdaLayer }
+    events:
+      - sqs:
+          arn: ${ssm:/data_portal/backend/sqs_dragen_tso_ctdna_queue_arn}
+    timeout: 28
+
   sqs_tumor_normal_event_processor:
     handler: data_processors.pipeline.lambdas.tumor_normal.sqs_handler
     layers:
@@ -180,6 +189,12 @@ functions:
 
   dragen_wgs_qc:
     handler: data_processors.pipeline.lambdas.dragen_wgs_qc.handler
+    layers:
+      - { Ref: PythonRequirementsLambdaLayer }
+    timeout: 28
+
+  dragen_tso_ctdna:
+    handler: data_processors.pipeline.lambdas.dragen_tso_ctdna.handler
     layers:
       - { Ref: PythonRequirementsLambdaLayer }
     timeout: 28

--- a/utils/tests/test_gds.py
+++ b/utils/tests/test_gds.py
@@ -1,6 +1,5 @@
 import csv
 import json
-import logging
 import os
 from contextlib import closing
 from tempfile import NamedTemporaryFile
@@ -9,33 +8,15 @@ from unittest import TestCase, skip
 
 import requests
 from libica.openapi import libgds
-from mockito import unstub, when, mock
+from mockito import when, mock
 
 from utils import gds
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+from utils.tests.test_ica import IcaUnitTests, logger
 
 gds_path = "gds://umccr-fastq-data-dev/200612_A01052_0017_BH5LYWDSXY/TSO-DNA_TSODNA/UMCCR/PTC_TSO200609VD_L2000552_S1_L003_R1_001.fastq.gz"
 
 
-class GdsUnitTests(TestCase):
-
-    def setUp(self) -> None:
-        super(GdsUnitTests, self).setUp()
-        os.environ['ICA_BASE_URL'] = "http://localhost"
-        os.environ['ICA_ACCESS_TOKEN'] = "mock"
-
-    def tearDown(self) -> None:
-        del os.environ['ICA_BASE_URL']
-        del os.environ['ICA_ACCESS_TOKEN']
-        unstub()
-
-    def verify_local(self):
-        logger.info(f"ICA_BASE_URL={os.getenv('ICA_BASE_URL')}")
-        assert os.environ['ICA_BASE_URL'] == "http://localhost"
-        assert os.environ['ICA_ACCESS_TOKEN'] == "mock"
-        self.assertEqual(os.environ['ICA_BASE_URL'], "http://localhost")
+class GdsUnitTests(IcaUnitTests):
 
     def test_parse_gds_path(self):
         """

--- a/utils/tests/test_ica.py
+++ b/utils/tests/test_ica.py
@@ -1,0 +1,31 @@
+import logging
+import os
+from unittest import TestCase
+
+from mockito import unstub
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class IcaUnitTests(TestCase):
+
+    def setUp(self) -> None:
+        super(IcaUnitTests, self).setUp()
+        os.environ['ICA_BASE_URL'] = "http://localhost"
+        os.environ['ICA_ACCESS_TOKEN'] = "mock"
+
+    def tearDown(self) -> None:
+        del os.environ['ICA_BASE_URL']
+        del os.environ['ICA_ACCESS_TOKEN']
+        unstub()
+
+    def verify_local(self):
+        logger.info(f"ICA_BASE_URL={os.getenv('ICA_BASE_URL')}")
+        assert os.environ['ICA_BASE_URL'] == "http://localhost"
+        assert os.environ['ICA_ACCESS_TOKEN'] == "mock"
+        self.assertEqual(os.environ['ICA_BASE_URL'], "http://localhost")
+
+
+class IcaIntegrationTests(TestCase):
+    pass

--- a/utils/tests/test_wes.py
+++ b/utils/tests/test_wes.py
@@ -1,0 +1,54 @@
+from unittest import skip
+
+from libica.openapi import libwes
+
+from utils import wes
+from utils.tests.test_ica import IcaUnitTests, IcaIntegrationTests, logger
+
+
+class WesUnitTests(IcaUnitTests):
+
+    def test_get_run(self):
+        """
+        python manage.py test utils.tests.test_wes.WesUnitTests.test_get_run
+        """
+        result = wes.get_run("wfr.13245678903214565")
+        self.assertTrue(isinstance(result, libwes.WorkflowRun))
+        self.assertIsNotNone(result)
+        logger.info(f"EXAMPLE MOCK WorkflowRun: \n{result}")
+
+    def test_get_run_to_dict(self):
+        """
+        python manage.py test utils.tests.test_wes.WesUnitTests.test_get_run_to_dict
+        """
+        result = wes.get_run("wfr.13245678903214565", to_dict=True)
+        self.assertTrue(isinstance(result, dict))
+        self.assertIsNotNone(result)
+        logger.info(f"EXAMPLE MOCK WorkflowRun to_dict(): \n{result}")
+
+    def test_get_run_to_json(self):
+        """
+        python manage.py test utils.tests.test_wes.WesUnitTests.test_get_run_to_json
+        """
+        result = wes.get_run("wfr.13245678903214565", to_json=True)
+        self.assertTrue(isinstance(result, str))
+        self.assertIsNotNone(result)
+        logger.info(f"EXAMPLE MOCK WorkflowRun to_json(): \n{result}")
+
+
+class WesIntegrationTests(IcaIntegrationTests):
+
+    @skip
+    def test_get_run(self):
+        """
+        python manage.py test utils.tests.test_wes.WesIntegrationTests.test_get_run
+        """
+        wfr_id = "wfr.81cf25d7226a4874be43e4b15c1f5687"
+        result = wes.get_run(wfr_id, to_dict=True)
+        self.assertEqual(result['id'], wfr_id)
+        self.assertIsNotNone(result['input'])
+        self.assertIsNotNone(result['output'])
+
+        # You may peak the result like so
+        # print(result['input'])
+        # print(result['output'])

--- a/utils/wes.py
+++ b/utils/wes.py
@@ -1,0 +1,34 @@
+import logging
+
+from libica.openapi import libwes
+
+from utils import ica, libjson
+
+logger = logging.getLogger()
+
+
+def get_run(wfr_id, to_dict=False, to_json=False):
+    """
+    Get workflow run from WES endpoint ala `ica workflows runs get wfr.81cf25dxxx`
+
+    :param wfr_id:
+    :param to_json: False by default
+    :param to_dict: False by default
+    :return: instance of libwes.WorkflowRun unless to_dict or to_json
+    """
+
+    with libwes.ApiClient(ica.configuration(libwes)) as api_client:
+        run_api = libwes.WorkflowRunsApi(api_client)
+        try:
+            logger.info(f"Getting '{wfr_id}' from WES RUN API endpoint")
+            wfl_run: libwes.WorkflowRun = run_api.get_workflow_run(run_id=wfr_id)
+
+            if to_dict:
+                return wfl_run.to_dict()
+
+            elif to_json:
+                return libjson.dumps(wfl_run.to_dict())
+
+            return wfl_run
+        except libwes.ApiException as e:
+            logger.error(f"Exception when calling get_workflow_run: \n{e}")


### PR DESCRIPTION
# Summary
* Used WGS QC secondary analysis as a starting point to build automatic kick off of ctTSO runs
* Additional complications include:
  * requiring the input directory from the previous bcl-convert run to get xml input files (`RunInfo.xml`, `RunParameters.xml`)
  * requiring the samplesheet used in the bclconvert step that demultiplexed the cttso samples


# TODO
- [x] create tests:
  - [x] Test `orchestration/ct_tso_step.py`
  - [x] Merge https://github.com/umccr/infrastructure/pull/154 to get SQS queue ssm parameter
  - [x] Test `lambdas/ct_tso.py`
- [x] Update ssm parameters on terraform --> https://github.com/umccr/infrastructure/pull/151
 