### PR TITLE
Implemented workaround non-ideal metadata lookup

### DIFF
--- a/data_portal/models.py
+++ b/data_portal/models.py
@@ -4,7 +4,8 @@ import uuid
 from typing import Union
 
 from django.db import models
-from django.db.models import Max, QuerySet, Q
+from django.db.models import Max, QuerySet, Q, Value
+from django.db.models.functions import Concat
 
 from data_portal.exceptions import RandSamplesTooLarge
 from data_portal.fields import HashField
@@ -273,6 +274,18 @@ class LabMetadataManager(models.Manager):
         if project:
             qs = qs.filter(project_name__iexact=project)
 
+        return qs
+
+    def get_by_sample_library_name(self, sample_library_name) -> QuerySet:
+        """
+        Here we project (or annotate) virtual attribute called "sample_library_name" which is using database built-in
+        concat function of two existing columns sample_id and library_id.
+
+        :param sample_library_name:
+        :return: QuerySet
+        """
+        qs: QuerySet = self.annotate(sample_library_name=Concat('sample_id', Value('_'), 'library_id'))
+        qs = qs.filter(sample_library_name__iexact=sample_library_name)
         return qs
 
 

--- a/data_processors/pipeline/lambdas/tests/test_bcl_convert.py
+++ b/data_processors/pipeline/lambdas/tests/test_bcl_convert.py
@@ -12,6 +12,7 @@ from data_portal.tests.factories import SequenceRunFactory, TestConstant
 from data_processors.pipeline.domain.workflow import WorkflowStatus
 from data_processors.pipeline.lambdas import bcl_convert
 from data_processors.pipeline.tests.case import logger, PipelineUnitTestCase, PipelineIntegrationTestCase
+from data_processors.pipeline.tools import liborca
 from utils import libslack
 
 
@@ -29,7 +30,7 @@ class BCLConvertUnitTests(PipelineUnitTestCase):
         mock_labmetadata.workflow = LabMetadataWorkflow.RESEARCH.value
         mock_labmetadata.save()
 
-        when(bcl_convert).get_sample_names_from_samplesheet(...).thenReturn(
+        when(liborca).get_sample_names_from_samplesheet(...).thenReturn(
             [
                 "PTC_EXPn200908LL_L2000001"
             ]
@@ -92,7 +93,7 @@ class BCLConvertUnitTests(PipelineUnitTestCase):
         """
 
         # This will fail metadata validation since there exists no samples
-        when(bcl_convert).get_sample_names_from_samplesheet(...).thenReturn(
+        when(liborca).get_sample_names_from_samplesheet(...).thenReturn(
             [
                 ""
             ]
@@ -283,24 +284,6 @@ class BCLConvertIntegrationTests(PipelineIntegrationTestCase):
     # Comment @skip
     # export AWS_PROFILE=dev
     # run the test
-
-    @skip
-    def test_get_sample_names_from_samplesheet(self):
-        """
-        python manage.py test data_processors.pipeline.lambdas.tests.test_bcl_convert.BCLConvertIntegrationTests.test_get_sample_names_from_samplesheet
-        """
-
-        # SEQ-II validation dataset
-        gds_volume = "umccr-raw-sequence-data-dev"
-        samplesheet_path = "/200612_A01052_0017_BH5LYWDSXY_r.Uvlx2DEIME-KH0BRyF9XBg/SampleSheet.csv"
-
-        sample_names = bcl_convert.get_sample_names_from_samplesheet(
-            gds_volume=gds_volume,
-            samplesheet_path=samplesheet_path
-        )
-
-        self.assertIsNotNone(sample_names)
-        self.assertTrue("PTC_SsCRE200323LL_L2000172_topup" in sample_names)
 
     @skip
     def test_get_metadata_df(self):

--- a/data_processors/pipeline/lambdas/tests/test_sqs_iap_event.py
+++ b/data_processors/pipeline/lambdas/tests/test_sqs_iap_event.py
@@ -12,6 +12,7 @@ from data_processors.pipeline.domain.workflow import WorkflowStatus, WorkflowTyp
 from data_processors.pipeline.lambdas import sqs_iap_event, bcl_convert
 from data_processors.pipeline.tests import _rand, _uuid
 from data_processors.pipeline.tests.case import logger, PipelineUnitTestCase
+from data_processors.pipeline.tools import liborca
 from utils import libslack, libjson
 
 
@@ -211,7 +212,7 @@ class SQSIAPEventUnitTests(PipelineUnitTestCase):
         mock_labmetadata_2.workflow = LabMetadataWorkflow.RESEARCH.value
         mock_labmetadata_2.save()
 
-        when(bcl_convert).get_sample_names_from_samplesheet(...).thenReturn(
+        when(liborca).get_sample_names_from_samplesheet(...).thenReturn(
             [
                 "PTC_EXPn200908LL_L2000001",
                 "PTC_EXPn200908LL_L2000001_topup"

--- a/data_processors/pipeline/tools/tests/test_liborca.py
+++ b/data_processors/pipeline/tools/tests/test_liborca.py
@@ -1,8 +1,9 @@
 import json
+from unittest import skip
 
 from data_portal.tests.factories import TestConstant
 from data_processors.pipeline.tools import liborca
-from data_processors.pipeline.tests.case import PipelineUnitTestCase, logger
+from data_processors.pipeline.tests.case import logger, PipelineUnitTestCase, PipelineIntegrationTestCase
 
 
 class LibOrcaUnitTests(PipelineUnitTestCase):
@@ -124,3 +125,27 @@ class LibOrcaUnitTests(PipelineUnitTestCase):
         logger.info(result)
         self.assertTrue(isinstance(result, dict))
         self.assertTrue("class" in result.keys())
+
+
+class LibOrcaIntegrationTests(PipelineIntegrationTestCase):
+    # Comment @skip
+    # export AWS_PROFILE=dev
+    # run the test
+
+    @skip
+    def test_get_sample_names_from_samplesheet(self):
+        """
+        python manage.py test data_processors.pipeline.tools.tests.test_liborca.LibOrcaIntegrationTests.test_get_sample_names_from_samplesheet
+        """
+
+        # SEQ-II validation dataset
+        gds_volume = "umccr-raw-sequence-data-dev"
+        samplesheet_path = "/200612_A01052_0017_BH5LYWDSXY_r.Uvlx2DEIME-KH0BRyF9XBg/SampleSheet.csv"
+
+        sample_names = liborca.get_sample_names_from_samplesheet(
+            gds_volume=gds_volume,
+            samplesheet_path=samplesheet_path
+        )
+
+        self.assertIsNotNone(sample_names)
+        self.assertTrue("PTC_SsCRE200323LL_L2000172_topup" in sample_names)


### PR DESCRIPTION
* For BCL Convert input, we need lookup Lab Metadata.
  Lookup by sample_name is not ideal as sample_name
  definition is ambiguous. For now this is sample_name
  as in SampleSheet i.e. sample_id_library_id
* Added support for legacy metadata entries but we wish to
  improve this by using minted Library ID in future!
