### PR TITLE
Harmonised Library ID use across metadata lookup

### DIFF
--- a/data_portal/tests/factories.py
+++ b/data_portal/tests/factories.py
@@ -6,7 +6,7 @@ import factory
 from django.utils.timezone import now, make_aware
 
 from data_portal.models import S3Object, LIMSRow, S3LIMS, GDSFile, SequenceRun, Workflow, Batch, BatchRun, \
-    Report, ReportType
+    Report, ReportType, LabMetadata
 from data_processors.pipeline.domain.workflow import WorkflowType, WorkflowStatus
 
 utc_now_ts = int(datetime.utcnow().replace(tzinfo=timezone.utc).timestamp())
@@ -23,6 +23,30 @@ class TestConstant(Enum):
     sample_id = "PRJ210001"
     sample_name_normal = f"{sample_id}_{library_id_normal}"
     sample_name_tumor = f"{sample_id}_{library_id_tumor}"
+
+
+class LabMetadataFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = LabMetadata
+
+    library_id = TestConstant.library_id_normal.value
+    sample_name = "Ambiguous Sample"
+    sample_id = TestConstant.sample_id.value
+    external_sample_id = "DNA123456"
+    subject_id = "SBJ000001"
+    external_subject_id = "PM1234567"
+    phenotype = "normal"
+    quality = "good"
+    source = "blood"
+    project_name = "CUP"
+    project_owner = "UMCCR"
+    experiment_id = "TSqN123456LL"
+    type = "WGS"
+    assay = "TsqNano"
+    override_cycles = "Y151;I8;I8;Y151"
+    workflow = "clinical"
+    coverage = "40.0"
+    truseqindex = "A09"
 
 
 class S3ObjectFactory(factory.django.DjangoModelFactory):

--- a/data_processors/pipeline/lambdas/bcl_convert.py
+++ b/data_processors/pipeline/lambdas/bcl_convert.py
@@ -226,7 +226,7 @@ def get_metadata_df(gds_volume: str, samplesheet_path: str) -> pd.DataFrame:
         # single_matched_entry: LabMetadata = metadata_srv.get_metadata_by_library_id(library_id)
         # all_matched_entries: List[LabMetadata] = metadata_srv.filter_metadata_by_library_id(library_id)
 
-        meta: LabMetadata = metadata_srv.get_metadata_by_sample_name_as_in_samplesheet(sample_name)
+        meta: LabMetadata = metadata_srv.get_metadata_by_sample_library_name_as_in_samplesheet(sample_name)
 
         if meta is None:
             logger.error(f"LabMetadata query for {sample_name} did not find any metadata!")

--- a/data_processors/pipeline/lambdas/dragen_tso_ctdna.py
+++ b/data_processors/pipeline/lambdas/dragen_tso_ctdna.py
@@ -108,13 +108,10 @@ def handler(event, context) -> dict:
     logger.info(f"Start processing {WorkflowType.DRAGEN_TSO_CTDNA.name} event")
     logger.info(libjson.dumps(event))
 
-    # Set sequence run id
     seq_run_id = event.get('seq_run_id', None)
     seq_name = event.get('seq_name', None)
-    # Set batch run id
     batch_run_id = event.get('batch_run_id', None)
-    # Get sample name
-    sample_name = event['tso500_sample']['sample_name']
+    library_id = event['library_id']
 
     # Set workflow helper
     wfl_helper = WorkflowHelper(WorkflowType.DRAGEN_TSO_CTDNA)
@@ -139,7 +136,7 @@ def handler(event, context) -> dict:
         type_name=WorkflowType.DRAGEN_TSO_CTDNA.name,
         wfl_id=workflow_id,
         version=workflow_version,
-        sample_name=sample_name,
+        sample_name=library_id,
         sequence_run=sqr,
         batch_run=batch_run
     )
@@ -171,7 +168,7 @@ def handler(event, context) -> dict:
     workflow_run_name = wfl_helper.construct_workflow_name(
         seq_name=seq_name,
         seq_run_id=seq_run_id,
-        sample_name=sample_name
+        sample_name=library_id
     )
 
     wfl_run = wes_handler.launch({
@@ -193,7 +190,7 @@ def handler(event, context) -> dict:
             'start': wfl_run.get('time_started'),
             'end_status': wfl_run.get('status'),
             'sequence_run': sqr,
-            'sample_name': sample_name,
+            'sample_name': library_id,
             'batch_run': batch_run,
         }
     )
@@ -201,7 +198,7 @@ def handler(event, context) -> dict:
     # notification shall trigger upon wes.run event created action in workflow_update lambda
 
     result = {
-        'sample_name': workflow.sample_name,
+        'library_id': workflow.sample_name,
         'id': workflow.id,
         'wfr_id': workflow.wfr_id,
         'wfr_name': workflow.wfr_name,

--- a/data_processors/pipeline/lambdas/tests/test_dragen_tso_ctdna.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_tso_ctdna.py
@@ -58,6 +58,7 @@ class DragenTsoCtDnaTests(PipelineUnitTestCase):
             },
             "seq_run_id": mock_sqr.run_id,
             "seq_name": mock_sqr.name,
+            "library_id": "sample_library",
         }, None)
 
         logger.info("-" * 32)
@@ -120,6 +121,7 @@ class DragenTsoCtDnaTests(PipelineUnitTestCase):
             },
             "seq_run_id": mock_sqr.run_id,
             "seq_name": mock_sqr.name,
+            "library_id": "sample_library",
         }, None)
         logger.info("-" * 32)
         logger.info("Example dragen_tso_ctdna.handler lambda output:")
@@ -149,7 +151,7 @@ class DragenTsoCtDnaTests(PipelineUnitTestCase):
         mock_dragen_tso_ctdna.type_name = WorkflowType.DRAGEN_TSO_CTDNA.name
         mock_dragen_tso_ctdna.wfl_id = libssm.get_ssm_param(wfl_helper.get_ssm_key_id())
         mock_dragen_tso_ctdna.version = libssm.get_ssm_param(wfl_helper.get_ssm_key_version())
-        mock_dragen_tso_ctdna.sample_name = "sample_name"
+        mock_dragen_tso_ctdna.sample_name = TestConstant.library_id_normal.value
         mock_dragen_tso_ctdna.sequence_run = mock_sqr
         mock_dragen_tso_ctdna.batch_run = mock_batch_run
         mock_dragen_tso_ctdna.start = make_aware(datetime.utcnow())
@@ -194,6 +196,7 @@ class DragenTsoCtDnaTests(PipelineUnitTestCase):
             "seq_run_id": mock_sqr.run_id,
             "seq_name": mock_sqr.name,
             "batch_run_id": mock_batch_run.id,
+            "library_id": TestConstant.library_id_normal.value,
         }, None)
 
         logger.info("-" * 32)
@@ -248,7 +251,8 @@ class DragenTsoCtDnaTests(PipelineUnitTestCase):
             },
             "seq_run_id": mock_sqr.run_id,
             "seq_name": mock_sqr.name,
-            "batch_run_id": 1
+            "batch_run_id": 1,
+            "library_id": "sample_library",
         }
 
         mock_event = {

--- a/data_processors/pipeline/services/tests/test_metadata_srv.py
+++ b/data_processors/pipeline/services/tests/test_metadata_srv.py
@@ -1,0 +1,89 @@
+from data_portal.models import Workflow, LabMetadata
+from data_portal.tests import factories
+from data_portal.tests.factories import TestConstant
+from data_processors.pipeline.domain.workflow import WorkflowType
+from data_processors.pipeline.services import metadata_srv
+from data_processors.pipeline.tests.case import logger, PipelineUnitTestCase
+
+
+class MetadataSrvUnitTests(PipelineUnitTestCase):
+
+    def setUp(self) -> None:
+        super(MetadataSrvUnitTests, self).setUp()
+
+    def test_get_metadata_by_library_id(self):
+        """
+        python manage.py test data_processors.pipeline.services.tests.test_metadata_srv.MetadataSrvUnitTests.test_get_metadata_by_library_id
+        """
+        mock_meta: LabMetadata = factories.LabMetadataFactory()
+        meta = metadata_srv.get_metadata_by_library_id(TestConstant.library_id_normal.value)
+        self.assertEqual(meta.library_id, mock_meta.library_id)
+
+    def test_get_metadata_by_library_id_not_found(self):
+        """
+        python manage.py test data_processors.pipeline.services.tests.test_metadata_srv.MetadataSrvUnitTests.test_get_metadata_by_library_id_not_found
+        """
+        mock_meta: LabMetadata = factories.LabMetadataFactory()
+        meta = metadata_srv.get_metadata_by_library_id("L_NOT_EXIST")
+        self.assertIsNone(meta)
+
+    def test_filter_metadata_by_library_id(self):
+        """
+        python manage.py test data_processors.pipeline.services.tests.test_metadata_srv.MetadataSrvUnitTests.test_filter_metadata_by_library_id
+        """
+        mock_meta: LabMetadata = factories.LabMetadataFactory()
+        meta_list = metadata_srv.filter_metadata_by_library_id(TestConstant.library_id_normal.value)
+        self.assertEqual(len(meta_list), 1)
+
+    def test_get_metadata_by_sample_library_name_as_in_samplesheet(self):
+        """
+        python manage.py test data_processors.pipeline.services.tests.test_metadata_srv.MetadataSrvUnitTests.test_get_metadata_by_sample_library_name_as_in_samplesheet
+        """
+        mock_meta: LabMetadata = factories.LabMetadataFactory()
+        meta: LabMetadata = metadata_srv.get_metadata_by_sample_library_name_as_in_samplesheet(
+            f"{TestConstant.sample_id.value}_{TestConstant.library_id_normal.value}"
+        )
+        self.assertEqual(meta.library_id, mock_meta.library_id)
+
+    def test_get_subjects_from_runs(self):
+        """
+        python manage.py test data_processors.pipeline.services.tests.test_metadata_srv.MetadataSrvUnitTests.test_get_subjects_from_runs
+        """
+        mock_meta: LabMetadata = factories.LabMetadataFactory()
+        mock_workflow = Workflow(
+            sample_name=TestConstant.library_id_normal.value,
+            type_name=WorkflowType.DRAGEN_WGS_QC.name,
+        )
+        subject_list = metadata_srv.get_subjects_from_runs([mock_workflow])
+        self.assertEqual(subject_list[0], mock_meta.subject_id)
+
+    def test_get_library_id_from_workflow(self):
+        """
+        python manage.py test data_processors.pipeline.services.tests.test_metadata_srv.MetadataSrvUnitTests.test_get_library_id_from_workflow
+        """
+
+        lib_id = metadata_srv.get_library_id_from_workflow(
+            Workflow(
+                sample_name=TestConstant.library_id_normal.value,
+                type_name=WorkflowType.DRAGEN_WGS_QC.name,
+            )
+        )
+        logger.info(lib_id)
+        self.assertEqual(lib_id, TestConstant.library_id_normal.value)
+
+        lib_id = metadata_srv.get_library_id_from_workflow(
+            Workflow(
+                sample_name=TestConstant.library_id_normal.value,
+                type_name=WorkflowType.DRAGEN_TSO_CTDNA.name,
+            )
+        )
+        logger.info(lib_id)
+        self.assertEqual(lib_id, TestConstant.library_id_normal.value)
+
+        lib_id = metadata_srv.get_library_id_from_workflow(
+            Workflow(
+                sample_name=TestConstant.sample_name_normal.value,
+            )
+        )
+        logger.info(lib_id)
+        self.assertEqual(lib_id, TestConstant.library_id_normal.value)


### PR DESCRIPTION
* For Portal DB Workflow run tracking, we should
  use Library ID. Better refactor plan in #244
* Beef up metadata unit testing
