### PR TITLE
Fastq API endpoint can be queried by project owner

### DIFF
--- a/data_portal/models.py
+++ b/data_portal/models.py
@@ -608,12 +608,13 @@ class FastqListRowManager(models.Manager):
 
         project_owner = kwargs.get('project_owner', None)
         if project_owner:
-            qs = qs.filter(lab_metadata__project_owner__iexact=project_owner)
+            qs_project_owner_libids = LabMetadata.objects.filter(project_owner__iexact=project_owner).values("library_id")
+            qs = qs.filter(rglb__in=qs_project_owner_libids)
 
         return qs
 
 
-    
+
 class FastqListRow(models.Model):   
     
     class Meta:
@@ -628,7 +629,6 @@ class FastqListRow(models.Model):
     read_2 = models.TextField(null=True, blank=True)  # This is nullable. Search 'read_2' in fastq_list_row.handler()
 
     sequence_run = models.ForeignKey(SequenceRun, on_delete=models.SET_NULL, null=True, blank=True)
-    lab_metadata = models.ForeignKey(LabMetadata, on_delete=models.SET_NULL, null=True, blank=True)
 
     objects = FastqListRowManager()
 
@@ -645,8 +645,6 @@ class FastqListRow(models.Model):
             "read_1": self.read_1,
             "read_2": self.read_2
         }
-        if self.lab_metadata:
-            d["project_owner"] = self.lab_metadata.project_owner
         return d
 
     def as_json(self):
@@ -662,8 +660,6 @@ class FastqListRow(models.Model):
         }
         if self.read_2:
             dict_obj["read_2"] = self.read_2_to_dict()
-        if self.lab_metadata:
-            dict_obj["project_owner"] = self.lab_metadata.project_owner
         return dict_obj
 
     def __json__(self):

--- a/data_portal/models.py
+++ b/data_portal/models.py
@@ -566,29 +566,12 @@ class SequenceRun(models.Model):
 
 class FastqListRowManager(models.Manager):
 
-    def create_fastq_list_row(self,rgid,rgsm,rglb,lane,read_1,read_2,sequence_run,lab_metadata):
-        flr = self.create(rgid=rgid,rgsm=rgsm,rglb=rglb,lane=lane,read_1=read_1,read_2=read_2,sequence_run=sequence_run)
-        lm = LabMetadata.objects.filter(library_id__iexact=rglb)
-
-        if len(lm) == 1:
-            flr.lab_metadata = lm[0]
-            flr.save()
-        return flr
-
     def get_by_keyword(self, **kwargs) -> QuerySet:
         qs: QuerySet = self.all()
 
-        sequence_run = kwargs.get('sequence_run', None)
-        if sequence_run:
-            qs = qs.filter(sequence_run_id__exact=sequence_run)
-
-        sequence = kwargs.get('sequence', None)
-        if sequence:
-            qs = qs.filter(sequence_run__name__iexact=sequence)
-
         run = kwargs.get('run', None)
         if run:
-            qs = qs.filter(sequence_run__name__iexact=run)
+            qs = qs.filter(sequence_run__instrument_run_id__exact=run)
 
         rgid = kwargs.get('rgid', None)
         if rgid:
@@ -608,11 +591,10 @@ class FastqListRowManager(models.Manager):
 
         project_owner = kwargs.get('project_owner', None)
         if project_owner:
-            qs_project_owner_libids = LabMetadata.objects.filter(project_owner__iexact=project_owner).values("library_id")
-            qs = qs.filter(rglb__in=qs_project_owner_libids)
+            qs_meta = LabMetadata.objects.filter(project_owner__iexact=project_owner).values("library_id")
+            qs = qs.filter(rglb__in=qs_meta)
 
         return qs
-
 
 
 class FastqListRow(models.Model):   

--- a/data_portal/models.py
+++ b/data_portal/models.py
@@ -613,7 +613,8 @@ class FastqListRow(models.Model):
     read_2 = models.TextField(null=True, blank=True)  # This is nullable. Search 'read_2' in fastq_list_row.handler()
 
     sequence_run = models.ForeignKey(SequenceRun, on_delete=models.SET_NULL, null=True, blank=True)
-
+    lab_metadata = models.ForeignKey(LabMetadata, on_delete=models.SET_NULL, null=True, blank=True)
+    
     objects = FastqListRowManager()
 
     def __str__(self):
@@ -629,6 +630,8 @@ class FastqListRow(models.Model):
             "read_1": self.read_1,
             "read_2": self.read_2
         }
+        if self.lab_metadata:
+            d["project_owner"] = self.lab_metadata.project_owner
         return d
 
     def as_json(self):
@@ -640,10 +643,12 @@ class FastqListRow(models.Model):
             "rglb": self.rglb,
             "rgsm": self.rgsm,
             "lane": self.lane,
-            "read_1": self.read_1_to_dict(),
+            "read_1": self.read_1_to_dict()
         }
         if self.read_2:
             dict_obj["read_2"] = self.read_2_to_dict()
+        if self.lab_metadata:
+            dict_obj["project_owner"] = self.lab_metadata.project_owner
         return dict_obj
 
     def __json__(self):

--- a/data_portal/tests/test_fastq_list_row.py
+++ b/data_portal/tests/test_fastq_list_row.py
@@ -15,10 +15,10 @@ class FastqListRowTests(TestCase):
     def test_retrieve_by_project_owner(self):
         # create a lab metadata and a FastqListRow and 
 
-        mock_id = "ABC123"
+        mock_lib_id = "ABC123"
         mock_project_owner = "A Programmer"
         lm: LabMetadata = LabMetadata(
-            library_id="ABC123",
+            library_id=mock_lib_id,
             sample_id="foobar",
             sample_name="foobar",
             phenotype="tumor",
@@ -31,7 +31,10 @@ class FastqListRowTests(TestCase):
 
         sequence_run: SequenceRun = SequenceRunFactory()
 
+        FastqListRow.objects.create_fastq_list_row("rg"+mock_lib_id,'rgsm',mock_lib_id,'1','read_1','read_2',sequence_run,None)      
+
+        results = FastqListRow.objects.get_by_keyword(project_owner=mock_project_owner)
+        
         # this ought to autolink to the labmetadata
-        FastqListRow.objects.create_fastq_list_row("rg"+mock_id,'rgsm',mock_id,'1','read_1','read_2',sequence_run,None)      
-        logger.info(FastqListRow.objects.filter(lab_metadata__project_owner__iexact=mock_project_owner))
-        self.assertEqual(FastqListRow.objects.filter(lab_metadata__project_owner__iexact=mock_project_owner).count(),1)
+        logger.info(results)
+        self.assertEqual(results.count(),1)

--- a/data_portal/tests/test_fastq_list_row.py
+++ b/data_portal/tests/test_fastq_list_row.py
@@ -1,10 +1,9 @@
 import logging
 
-from django.db import IntegrityError
 from django.test import TestCase
 
-from data_portal.models import LabMetadata,FastqListRow,FastqListRowManager, SequenceRun
-from data_portal.tests.factories import LabMetadataFactory, SequenceRunFactory
+from data_portal.models import LabMetadata, FastqListRow, SequenceRun
+from data_portal.tests.factories import SequenceRunFactory
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -13,11 +12,14 @@ logger.setLevel(logging.INFO)
 class FastqListRowTests(TestCase):
 
     def test_retrieve_by_project_owner(self):
-        # create a lab metadata and a FastqListRow and 
+        """
+        python manage.py test data_portal.tests.test_fastq_list_row.FastqListRowTests.test_retrieve_by_project_owner
+        """
 
-        mock_lib_id = "ABC123"
-        mock_project_owner = "A Programmer"
-        lm: LabMetadata = LabMetadata(
+        mock_lib_id = "L1234567"
+        mock_project_owner = "Scott"
+
+        mock_meta: LabMetadata = LabMetadata(
             library_id=mock_lib_id,
             sample_id="foobar",
             sample_name="foobar",
@@ -26,15 +28,29 @@ class FastqListRowTests(TestCase):
             source="tissue",
             type="WGS",
             assay="TsqNano",
-            project_owner=mock_project_owner)              
-        lm.save()
+            project_owner=mock_project_owner)
+        mock_meta.save()
 
-        sequence_run: SequenceRun = SequenceRunFactory()
+        mock_sequence_run: SequenceRun = SequenceRunFactory()
 
-        FastqListRow.objects.create_fastq_list_row("rg"+mock_lib_id,'rgsm',mock_lib_id,'1','read_1','read_2',sequence_run,None)      
+        mock_fqlr = FastqListRow(
+            rgid=f"CTCAGAAG.AACTTGCC.4.210923_A00130_0001_BHH5JFDSX2.PRJ123456_{mock_lib_id}",
+            rgsm="PRJ123456",
+            rglb=mock_lib_id,
+            lane=1,
+            read_1="gds://volume/path_R1.fastq.gz",
+            read_2="gds://volume/path_R2.fastq.gz",
+            sequence_run=mock_sequence_run
+        )
+        mock_fqlr.save()
 
-        results = FastqListRow.objects.get_by_keyword(project_owner=mock_project_owner)
-        
-        # this ought to autolink to the labmetadata
-        logger.info(results)
-        self.assertEqual(results.count(),1)
+        results = FastqListRow.objects.get_by_keyword(
+            run=mock_sequence_run.instrument_run_id,
+            project_owner=mock_project_owner
+        )
+
+        self.assertEqual(results.count(), 1)
+
+        fqlr = results.get()
+        logger.info(fqlr)
+        self.assertEqual(fqlr.rglb, mock_lib_id)

--- a/data_portal/tests/test_fastq_list_row.py
+++ b/data_portal/tests/test_fastq_list_row.py
@@ -1,0 +1,37 @@
+import logging
+
+from django.db import IntegrityError
+from django.test import TestCase
+
+from data_portal.models import LabMetadata,FastqListRow,FastqListRowManager, SequenceRun
+from data_portal.tests.factories import LabMetadataFactory, SequenceRunFactory
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class FastqListRowTests(TestCase):
+
+    def test_retrieve_by_project_owner(self):
+        # create a lab metadata and a FastqListRow and 
+
+        mock_id = "ABC123"
+        mock_project_owner = "A Programmer"
+        lm: LabMetadata = LabMetadata(
+            library_id="ABC123",
+            sample_id="foobar",
+            sample_name="foobar",
+            phenotype="tumor",
+            quality="good",
+            source="tissue",
+            type="WGS",
+            assay="TsqNano",
+            project_owner=mock_project_owner)              
+        lm.save()
+
+        sequence_run: SequenceRun = SequenceRunFactory()
+
+        # this ought to autolink to the labmetadata
+        FastqListRow.objects.create_fastq_list_row("rg"+mock_id,'rgsm',mock_id,'1','read_1','read_2',sequence_run,None)      
+        logger.info(FastqListRow.objects.filter(lab_metadata__project_owner__iexact=mock_project_owner))
+        self.assertEqual(FastqListRow.objects.filter(lab_metadata__project_owner__iexact=mock_project_owner).count(),1)

--- a/data_portal/viewsets.py
+++ b/data_portal/viewsets.py
@@ -332,6 +332,8 @@ class FastqListRowViewSet(ReadOnlyModelViewSet):
         rgsm = self.request.query_params.get('rgsm', None)
         rglb = self.request.query_params.get('rglb', None)
         lane = self.request.query_params.get('lane', None)
+        project_owner = self.request.query_params.get('project_owner', None)
+        
         return FastqListRow.objects.get_by_keyword(
             sequence_run=sequence_run,
             sequence=sequence,
@@ -340,6 +342,7 @@ class FastqListRowViewSet(ReadOnlyModelViewSet):
             rgsm=rgsm,
             rglb=rglb,
             lane=lane,
+            project_owner=project_owner
         )
 
 

--- a/data_portal/viewsets.py
+++ b/data_portal/viewsets.py
@@ -325,8 +325,6 @@ class FastqListRowViewSet(ReadOnlyModelViewSet):
     search_fields = ordering_fields
 
     def get_queryset(self):
-        sequence_run = self.request.query_params.get('sequence_run', None)
-        sequence = self.request.query_params.get('sequence', None)
         run = self.request.query_params.get('run', None)
         rgid = self.request.query_params.get('rgid', None)
         rgsm = self.request.query_params.get('rgsm', None)
@@ -335,8 +333,6 @@ class FastqListRowViewSet(ReadOnlyModelViewSet):
         project_owner = self.request.query_params.get('project_owner', None)
         
         return FastqListRow.objects.get_by_keyword(
-            sequence_run=sequence_run,
-            sequence=sequence,
             run=run,
             rgid=rgid,
             rgsm=rgsm,

--- a/data_processors/pipeline/services/fastq_srv.py
+++ b/data_processors/pipeline/services/fastq_srv.py
@@ -4,8 +4,7 @@ from typing import List
 from django.db import transaction
 from django.db.models import QuerySet
 
-from data_portal.models import SequenceRun, FastqListRow, LabMetadata
-
+from data_portal.models import SequenceRun, FastqListRow
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -48,7 +47,6 @@ def create_or_update_fastq_list_row(fastq_list_row: dict, sequence_run: Sequence
         flr.read_1 = read_1
         flr.read_2 = read_2
         flr.sequence_run = sequence_run
-
     else:
         # update to updatable attributes i.e.
         # Depends on business logic requirement, we may decide a particular attribute is "immutable" across different
@@ -76,17 +74,6 @@ def get_fastq_list_row_by_sequence_name(sequence_name):
 
 
 @transaction.atomic
-def get_fastq_list_row_by_project_owner(owner_name):
-    qs_project_owner_libids = LabMetadata.objects.filter(project_owner__iexact=owner_name).values("library_id")
-    qs = FastqListRow.objects.filter(rglb__in=qs_project_owner_libids)
-    if qs.exists():
-        fqlr_list = []
-        for fqlr in qs.all():
-            fqlr_list.append(fqlr.as_dict())
-        return fqlr_list
-    return None
-
-@transaction.atomic
 def get_fastq_list_row_by_rgid(rgid):
     try:
         fastq_list_row = FastqListRow.objects.get(rgid=rgid)
@@ -104,6 +91,7 @@ def get_fastq_list_row_by_rglb(rglb) -> List[FastqListRow]:
         for fqlr in qs.all():
             fqlr_list.append(fqlr)
     return fqlr_list
+
 
 def extract_sample_library_ids(fastq_list_rows: List[FastqListRow]):
     samples = set()

--- a/data_processors/pipeline/services/fastq_srv.py
+++ b/data_processors/pipeline/services/fastq_srv.py
@@ -28,7 +28,6 @@ def create_or_update_fastq_list_row(fastq_list_row: dict, sequence_run: Sequence
     :param sequence_run:
     :return:
     """
-
     rgid: str = fastq_list_row['rgid']
     rgsm: str = fastq_list_row['rgsm']
     rglb: str = fastq_list_row['rglb']

--- a/data_processors/pipeline/services/fastq_srv.py
+++ b/data_processors/pipeline/services/fastq_srv.py
@@ -48,9 +48,6 @@ def create_or_update_fastq_list_row(fastq_list_row: dict, sequence_run: Sequence
         flr.read_1 = read_1
         flr.read_2 = read_2
         flr.sequence_run = sequence_run
-        lm = LabMetadata.objects.filter(library_id__iexact=rglb) # todo try with get
-        if len(lm) == 1:
-            flr.lab_metadata = lm[0]
 
     else:
         # update to updatable attributes i.e.
@@ -64,9 +61,6 @@ def create_or_update_fastq_list_row(fastq_list_row: dict, sequence_run: Sequence
         flr.read_1 = read_1
         flr.read_2 = read_2
         flr.sequence_run = sequence_run
-        lm = LabMetadata.objects.filter(library_id__iexact=rglb)  
-        if len(lm) == 1:
-            flr.lab_metadata = lm[0]
     flr.save()
 
 
@@ -83,7 +77,8 @@ def get_fastq_list_row_by_sequence_name(sequence_name):
 
 @transaction.atomic
 def get_fastq_list_row_by_project_owner(owner_name):
-    qs = FastqListRow.objects.filter(lab_metadata__project_owner__iexact=owner_name)
+    qs_project_owner_libids = LabMetadata.objects.filter(project_owner__iexact=owner_name).values("library_id")
+    qs = FastqListRow.objects.filter(rglb__in=qs_project_owner_libids)
     if qs.exists():
         fqlr_list = []
         for fqlr in qs.all():
@@ -109,7 +104,6 @@ def get_fastq_list_row_by_rglb(rglb) -> List[FastqListRow]:
         for fqlr in qs.all():
             fqlr_list.append(fqlr)
     return fqlr_list
-
 
 def extract_sample_library_ids(fastq_list_rows: List[FastqListRow]):
     samples = set()

--- a/data_processors/pipeline/services/tests/test_fastq_srv.py
+++ b/data_processors/pipeline/services/tests/test_fastq_srv.py
@@ -1,13 +1,19 @@
 from typing import List
 
-from data_portal.models import FastqListRow, SequenceRun
+from data_portal.models import FastqListRow, SequenceRun, LabMetadata
 from data_portal.tests import factories
 from data_processors.pipeline.services import fastq_srv
 from data_processors.pipeline.tests.case import logger, PipelineUnitTestCase
 from utils import libjson
 
+from data_portal.tests.factories import TestConstant
+from data_processors.pipeline.services import metadata_srv
 
 class FastqSrvUnitTests(PipelineUnitTestCase):
+    mock_library_id = "132"
+    mock_sample_id = "1"
+    mock_rgms_1 = "1"
+    mock_project_owner = "MyMockOwner"
 
     def setUp(self) -> None:
         super(FastqSrvUnitTests, self).setUp()
@@ -33,3 +39,72 @@ class FastqSrvUnitTests(PipelineUnitTestCase):
         logger.info(libjson.dumps(fqlr_list))
         self.assertTrue(isinstance(fqlr_list, List))
         self.assertTrue(isinstance(fqlr_list[0]['read_1'], str))  # assert that it is not transformed CWL File object
+
+    def test_get_fastq_list_row_by_project_owner(self):
+        """
+        python manage.py test data_processors.pipeline.services.tests.test_fastq_srv.FastqSrvUnitTests.test_get_fastq_list_row_by_project_owner
+        """
+        mock_meta: LabMetadata = factories.LabMetadataFactory()
+        mock_sqr: SequenceRun = factories.SequenceRunFactory()
+
+        meta = metadata_srv.get_metadata_by_library_id(TestConstant.library_id_normal.value)
+
+        mock_fqlr = FastqListRow()
+        mock_fqlr.rgid = f"TCCGGAGA.AGGATAGG.1.{mock_sqr.name}.PRJ123456_L1234567"
+        mock_fqlr.rglb = "L1234567"
+        mock_fqlr.rgsm = "PRJ123456"
+        mock_fqlr.lane = 1
+        mock_fqlr.read_1 = f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R1_001.fastq.gz"
+        mock_fqlr.read_2 = f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R2_001.fastq.gz"
+        mock_fqlr.sequence_run = mock_sqr
+        mock_fqlr.lab_metadata = meta
+        mock_fqlr.save()
+
+        fqlr_list = fastq_srv.get_fastq_list_row_by_project_owner(mock_meta.project_owner)
+        logger.info(libjson.dumps(fqlr_list))
+        self.assertTrue(isinstance(fqlr_list, List))
+        self.assertTrue(isinstance(fqlr_list[0]['read_1'], str))  # assert that it is not transformed CWL File object
+
+    def create_lab_meta(self):
+        mock_lab_meta: LabMetadata = LabMetadata(
+            library_id=self.mock_library_id,
+            sample_id=self.mock_sample_id,
+            sample_name=self.mock_rgms_1,
+            phenotype="tumor",
+            quality="good",
+            source="tissue",
+            type="WGS",
+            assay="TsqNano",
+            project_owner=self.mock_project_owner,
+        )
+        mock_lab_meta.save()
+        return mock_lab_meta
+
+    def test_create_fastq_list_row_and_fetch_by_project_owner(self): #todo u also ned a WRITE one
+        """
+        python manage.py test data_processors.pipeline.services.tests.test_fastq_srv.FastqSrvUnitTests.test_create_fastq_list_row_and_fetch_by_project_owner
+        """
+        mock_sqr: SequenceRun = factories.SequenceRunFactory()
+
+        # create a lab meta with mock_library_id
+        labmeta = self.create_lab_meta()
+
+        # create a fqlr with the correct labmeta - service should autolink projectowner
+        mock_fqlr_dict = {
+            "rgid" : f"TCCGGAGA.AGGATAGG.1.{mock_sqr.name}.PRJ123456_L1234567",
+            "rglb" : self.mock_library_id,
+            "rgsm" : "PRJ123456",
+            "lane" : 1,
+            "read_1" : f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R1_001.fastq.gz",
+            "read_2" : f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R2_001.fastq.gz"
+        }
+        mock_fqlr = fastq_srv.create_or_update_fastq_list_row(mock_fqlr_dict,mock_sqr)
+
+        fqlr_list = fastq_srv.get_fastq_list_row_by_project_owner(self.mock_project_owner)
+
+        logger.info(libjson.dumps(fqlr_list))
+        logger.info(labmeta)
+        self.assertTrue(fqlr_list[0]['project_owner'] == labmeta.project_owner)
+        self.assertTrue(fqlr_list[0]['rglb'] == self.mock_library_id)
+        self.assertTrue(isinstance(fqlr_list, List))
+        self.assertTrue(isinstance(fqlr_list[0]['read_1'], str))  # assert that it is not transformed CWL File object    

--- a/data_processors/pipeline/services/tests/test_fastq_srv.py
+++ b/data_processors/pipeline/services/tests/test_fastq_srv.py
@@ -1,19 +1,13 @@
 from typing import List
 
-from data_portal.models import FastqListRow, SequenceRun, LabMetadata
+from data_portal.models import FastqListRow, SequenceRun
 from data_portal.tests import factories
 from data_processors.pipeline.services import fastq_srv
 from data_processors.pipeline.tests.case import logger, PipelineUnitTestCase
 from utils import libjson
 
-from data_portal.tests.factories import TestConstant
-from data_processors.pipeline.services import metadata_srv
 
 class FastqSrvUnitTests(PipelineUnitTestCase):
-    mock_library_id = "132"
-    mock_sample_id = "1"
-    mock_rgms_1 = "1"
-    mock_project_owner = "MyMockOwner"
 
     def setUp(self) -> None:
         super(FastqSrvUnitTests, self).setUp()
@@ -39,41 +33,3 @@ class FastqSrvUnitTests(PipelineUnitTestCase):
         logger.info(libjson.dumps(fqlr_list))
         self.assertTrue(isinstance(fqlr_list, List))
         self.assertTrue(isinstance(fqlr_list[0]['read_1'], str))  # assert that it is not transformed CWL File object
-
-    def test_create_fastq_list_row_and_fetch_by_project_owner(self): 
-        """
-        python manage.py test data_processors.pipeline.services.tests.test_fastq_srv.FastqSrvUnitTests.test_create_fastq_list_row_and_fetch_by_project_owner
-        """
-        mock_sqr: SequenceRun = factories.SequenceRunFactory()
-
-        # create a lab meta with mock_library_id
-        mock_lab_meta: LabMetadata = LabMetadata(
-            library_id=self.mock_library_id,
-            sample_id=self.mock_sample_id,
-            sample_name=self.mock_rgms_1,
-            phenotype="tumor",
-            quality="good",
-            source="tissue",
-            type="WGS",
-            assay="TsqNano",
-            project_owner=self.mock_project_owner,
-        )
-        mock_lab_meta.save()
-
-        # create a fqlr with the correct labmeta - service should autolink projectowner
-        mock_fqlr_dict = {
-            "rgid" : f"TCCGGAGA.AGGATAGG.1.{mock_sqr.name}.PRJ123456_L1234567",
-            "rglb" : self.mock_library_id,
-            "rgsm" : "PRJ123456",
-            "lane" : 1,
-            "read_1" : f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R1_001.fastq.gz",
-            "read_2" : f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R2_001.fastq.gz"
-        }
-
-        mock_fqlr = fastq_srv.create_or_update_fastq_list_row(mock_fqlr_dict,mock_sqr)
-        fqlr_list = fastq_srv.get_fastq_list_row_by_project_owner(self.mock_project_owner)
-
-        logger.info(libjson.dumps(fqlr_list))
-        self.assertTrue(fqlr_list[0]['rglb'] == self.mock_library_id)
-        self.assertTrue(isinstance(fqlr_list, List))
-        self.assertTrue(isinstance(fqlr_list[0]['read_1'], str))  # assert that it is not transformed CWL File object    

--- a/data_processors/pipeline/services/tests/test_fastq_srv.py
+++ b/data_processors/pipeline/services/tests/test_fastq_srv.py
@@ -40,32 +40,13 @@ class FastqSrvUnitTests(PipelineUnitTestCase):
         self.assertTrue(isinstance(fqlr_list, List))
         self.assertTrue(isinstance(fqlr_list[0]['read_1'], str))  # assert that it is not transformed CWL File object
 
-    def test_get_fastq_list_row_by_project_owner(self):
+    def test_create_fastq_list_row_and_fetch_by_project_owner(self): 
         """
-        python manage.py test data_processors.pipeline.services.tests.test_fastq_srv.FastqSrvUnitTests.test_get_fastq_list_row_by_project_owner
+        python manage.py test data_processors.pipeline.services.tests.test_fastq_srv.FastqSrvUnitTests.test_create_fastq_list_row_and_fetch_by_project_owner
         """
-        mock_meta: LabMetadata = factories.LabMetadataFactory()
         mock_sqr: SequenceRun = factories.SequenceRunFactory()
 
-        meta = metadata_srv.get_metadata_by_library_id(TestConstant.library_id_normal.value)
-
-        mock_fqlr = FastqListRow()
-        mock_fqlr.rgid = f"TCCGGAGA.AGGATAGG.1.{mock_sqr.name}.PRJ123456_L1234567"
-        mock_fqlr.rglb = "L1234567"
-        mock_fqlr.rgsm = "PRJ123456"
-        mock_fqlr.lane = 1
-        mock_fqlr.read_1 = f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R1_001.fastq.gz"
-        mock_fqlr.read_2 = f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R2_001.fastq.gz"
-        mock_fqlr.sequence_run = mock_sqr
-        mock_fqlr.lab_metadata = meta
-        mock_fqlr.save()
-
-        fqlr_list = fastq_srv.get_fastq_list_row_by_project_owner(mock_meta.project_owner)
-        logger.info(libjson.dumps(fqlr_list))
-        self.assertTrue(isinstance(fqlr_list, List))
-        self.assertTrue(isinstance(fqlr_list[0]['read_1'], str))  # assert that it is not transformed CWL File object
-
-    def create_lab_meta(self):
+        # create a lab meta with mock_library_id
         mock_lab_meta: LabMetadata = LabMetadata(
             library_id=self.mock_library_id,
             sample_id=self.mock_sample_id,
@@ -78,16 +59,6 @@ class FastqSrvUnitTests(PipelineUnitTestCase):
             project_owner=self.mock_project_owner,
         )
         mock_lab_meta.save()
-        return mock_lab_meta
-
-    def test_create_fastq_list_row_and_fetch_by_project_owner(self): #todo u also ned a WRITE one
-        """
-        python manage.py test data_processors.pipeline.services.tests.test_fastq_srv.FastqSrvUnitTests.test_create_fastq_list_row_and_fetch_by_project_owner
-        """
-        mock_sqr: SequenceRun = factories.SequenceRunFactory()
-
-        # create a lab meta with mock_library_id
-        labmeta = self.create_lab_meta()
 
         # create a fqlr with the correct labmeta - service should autolink projectowner
         mock_fqlr_dict = {
@@ -98,12 +69,11 @@ class FastqSrvUnitTests(PipelineUnitTestCase):
             "read_1" : f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R1_001.fastq.gz",
             "read_2" : f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R2_001.fastq.gz"
         }
+
         mock_fqlr = fastq_srv.create_or_update_fastq_list_row(mock_fqlr_dict,mock_sqr)
         fqlr_list = fastq_srv.get_fastq_list_row_by_project_owner(self.mock_project_owner)
 
         logger.info(libjson.dumps(fqlr_list))
-        logger.info(labmeta)
-        self.assertTrue(fqlr_list[0]['project_owner'] == labmeta.project_owner)
         self.assertTrue(fqlr_list[0]['rglb'] == self.mock_library_id)
         self.assertTrue(isinstance(fqlr_list, List))
         self.assertTrue(isinstance(fqlr_list[0]['read_1'], str))  # assert that it is not transformed CWL File object    

--- a/data_processors/pipeline/services/tests/test_fastq_srv.py
+++ b/data_processors/pipeline/services/tests/test_fastq_srv.py
@@ -99,7 +99,6 @@ class FastqSrvUnitTests(PipelineUnitTestCase):
             "read_2" : f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R2_001.fastq.gz"
         }
         mock_fqlr = fastq_srv.create_or_update_fastq_list_row(mock_fqlr_dict,mock_sqr)
-
         fqlr_list = fastq_srv.get_fastq_list_row_by_project_owner(self.mock_project_owner)
 
         logger.info(libjson.dumps(fqlr_list))


### PR DESCRIPTION
Allows the fastq api endpoint to be queried by project owner - lab_metadata is now linked to fastqlistrow much like sequence_run is.
Note that in this PR we explicitly link lab_metadata to fastqlistrow by LibraryId/rgld at two points:
1. fastq service (fastq_srv)'s create_or_update_fastq_list_row function
2. fastqlistrowManager's create_fastq_list_row
...I am not certain if, in practtice on a running production system, whether that is enough? Do we indeed expect instnatiations to happen by fastq_srv? loaddata doesn't load in the linked lab_metadatas but that's because its an SQL import as far as I can tell...