### PR TITLE
Updated DRAGEN WGS QC workflow lane aware and no merge

### DIFF
--- a/data_processors/pipeline/lambdas/tests/test_dragen_wgs_qc.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_wgs_qc.py
@@ -25,6 +25,7 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
 
         workflow: dict = dragen_wgs_qc.handler({
             "library_id": "L0000001",
+            "lane": 1,
             "fastq_list_rows": [
                 {
                     "rgid": "index1.index2.lane",
@@ -58,7 +59,7 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
         python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_wgs_qc.DragenWgsQcUnitTests.test_handler_alt
         """
         mock_sqr: SequenceRun = SequenceRunFactory()
-        when(metadata_srv).get_subject_id_from_library_id(...).thenReturn("SBJ0001")
+        when(metadata_srv).get_subject_id_from_library_id(...).thenReturn("SBJ00001")
 
         mock_wfr: libwes.WorkflowRun = libwes.WorkflowRun()
         mock_wfr.id = TestConstant.wfr_id.value
@@ -71,6 +72,7 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
 
         workflow: dict = dragen_wgs_qc.handler({
             "library_id": "SAMPLE_NAME",
+            "lane": 1,
             "fastq_list_rows": [
                 {
                     "rgid": "index1.index2.lane",
@@ -120,6 +122,7 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
 
         result: dict = dragen_wgs_qc.handler({
             "library_id": "SAMPLE_NAME",
+            "lane": 1,
             "fastq_list_rows": [
                 {
                     "rgid": "index1.index2.lane",
@@ -159,6 +162,7 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
 
         mock_job = {
             "library_id": "SAMPLE_NAME",
+            "lane": 1,
             "fastq_list_rows": [
                 {
                     "rgid": "index1.index2.lane",

--- a/data_processors/pipeline/lambdas/tests/test_orchestrator.py
+++ b/data_processors/pipeline/lambdas/tests/test_orchestrator.py
@@ -45,7 +45,7 @@ class OrchestratorUnitTests(PipelineUnitTestCase):
         ]
         """
         try:
-            orchestrator.next_step(mock_workflow, None)
+            orchestrator.next_step(mock_workflow, [], None)
         except Exception as e:
             logger.exception(f"THIS ERROR EXCEPTION IS INTENTIONAL FOR TEST. NOT ACTUAL ERROR. \n{e}")
         self.assertRaises(json.JSONDecodeError)

--- a/data_processors/pipeline/orchestration/tests/test_dragen_wgs_qc_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_wgs_qc_step.py
@@ -160,11 +160,11 @@ class DragenWgsQcStepIntegrationTests(PipelineIntegrationTestCase):
         """
 
         # --- pick one successful BCL Convert run in development project
+        # ica workflows runs list
+        # ica workflows runs get wfr.<ID>
 
-        # FIXME required to switch PROD `export AWS_PROFILE=prod` as no validation run data avail in DEV yet
-        #   use `ica workflows runs get wfr.xxx` to see run details
         bcl_convert_wfr_id = "wfr.18210c790f30452992c5fd723521f014"
-        total_jobs_to_eval = 8
+        total_jobs_to_eval = 12
 
         # --- we need to rewind & replay pipeline state in the test db (like cassette tape, ya know!)
 
@@ -172,8 +172,7 @@ class DragenWgsQcStepIntegrationTests(PipelineIntegrationTestCase):
         # - we need metadata!
         # - populate LabMetadata tables in test db
         from data_processors.lims.lambdas import labmetadata
-        labmetadata.scheduled_update_handler({'sheet': "2020"}, None)
-        labmetadata.scheduled_update_handler({'sheet': "2021"}, None)
+        labmetadata.scheduled_update_handler({'event': "test_prepare_dragen_wgs_qc_jobs"}, None)
         logger.info(f"Lab metadata count: {LabMetadata.objects.count()}")
 
         # second --


### PR DESCRIPTION
* Producer: Updated `dragen_wgs_qc_step` produce job with lane aware (aka LibraryRun)
* Consumer: Updated `dragen_wgs_qc` take in account rglb + lane (aka LibraryRun)
  including engine parameters `mid_path` formation
