### PR TITLE
Added succeeded runs filter to dragen_tso_ctdna_step

### DIFF
--- a/data_processors/pipeline/orchestration/tests/test_dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_tso_ctdna_step.py
@@ -16,7 +16,7 @@ from data_processors.pipeline.domain.batch import Batcher
 from data_processors.pipeline.domain.workflow import WorkflowStatus, WorkflowType
 from data_processors.pipeline.lambdas import orchestrator
 from data_processors.pipeline.orchestration import fastq_update_step, dragen_tso_ctdna_step
-from data_processors.pipeline.services import batch_srv, fastq_srv
+from data_processors.pipeline.services import batch_srv, fastq_srv, libraryrun_srv
 from data_processors.pipeline.tests.case import PipelineIntegrationTestCase, PipelineUnitTestCase, logger
 
 tn_mock_subject_id = "SBJ00001"
@@ -220,6 +220,7 @@ class DragenTsoCtDnaStepIntegrationTests(PipelineIntegrationTestCase):
         # - grab workflow run from WES endpoint
         # - sync input and output attributes to our mock BCL Convert workflow in db
         bcl_convert_run = wes.get_run(bcl_convert_wfr_id, to_dict=True)
+        mock_bcl_convert.wfr_id = bcl_convert_wfr_id
         mock_bcl_convert.input = json.dumps(bcl_convert_run['input'])
         mock_bcl_convert.output = json.dumps(bcl_convert_run['output'])
         mock_bcl_convert.save()
@@ -229,7 +230,260 @@ class DragenTsoCtDnaStepIntegrationTests(PipelineIntegrationTestCase):
         fastq_update_step.perform(mock_bcl_convert)
 
         # fifth --
-        # - we also need Batch and BatchRun since DRAGEN_WGS_QC workflows (jobs) are running in batch manner
+        # - we also need Batch and BatchRun since workflows (jobs) are running in batch manner
+        # - we will use Batcher to create them, just like in dragen_wgs_qc_step.perform()
+        batcher = Batcher(
+            workflow=mock_bcl_convert,
+            run_step=WorkflowType.DRAGEN_TSO_CTDNA.value,
+            batch_srv=batch_srv,
+            fastq_srv=fastq_srv,
+            logger=logger
+        )
+
+        logger.info("-" * 32)
+        logger.info("PREPARE DRAGEN_TSO_CTDNA JOBS:")
+
+        job_list = dragen_tso_ctdna_step.prepare_dragen_tso_ctdna_jobs(batcher)
+
+        logger.info("-" * 32)
+        logger.info("JOB LIST JSON:")
+        logger.info(json.dumps(job_list))
+        logger.info("YOU SHOULD COPY ABOVE JSON INTO A FILE, FORMAT IT AND CHECK THAT IT LOOKS ALRIGHT")
+        self.assertIsNotNone(job_list)
+        self.assertEqual(len(job_list), total_jobs_to_eval)
+
+    @skip
+    def test_prepare_dragen_tso_ctdna_jobs_70(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_tso_ctdna_step.DragenTsoCtDnaStepIntegrationTests.test_prepare_dragen_tso_ctdna_jobs_70
+        """
+
+        # --- pick one successful BCL Convert run in development project
+
+        # 211213_A01052_0070_BH35KVDMXY in PROD
+
+        # https://umccr.slack.com/archives/C8CG6K76W/p1639502718024500
+        bssh_run_event = {
+            'gds_volume_name': "bssh.acddbfda498038ed99fa94fe79523959",
+            'gds_folder_path': "/Runs/211213_A01052_0070_BH35KVDMXY_r.0WSDrjeaoUGp61OMbpwbGQ",
+            'instrument_run_id': "211213_A01052_0070_BH35KVDMXY",
+            'run_id': "r.0WSDrjeaoUGp61OMbpwbGQ",
+        }
+
+        # https://umccr.slack.com/archives/C8CG6K76W/p1639509879024800
+        bcl_convert_wfr_id = "wfr.aae6970808bf4b328873b9278777332b"
+        total_jobs_to_eval = 9
+
+        # --- we need to rewind & replay pipeline state in the test db (like cassette tape, ya know!)
+
+        def deep_replay():
+            from data_processors.pipeline.lambdas import libraryrun
+            libraryrun.handler(bssh_run_event, None)
+
+            # https://umccr.slack.com/archives/C8CG6K76W/p1639550197031800
+            run_pairs = [
+                ("L2101514", "wfr.5f812da668334a84b33e926fd02ce3d9"),
+                ("L2101515", "wfr.d20c4352ff9f4f099876a95b17cb7824"),
+                ("L2101516", "wfr.03e54a22601b44edb7e6c0c51c4b6d4b"),
+                ("L2101517", "wfr.afaf17f489994948bdbbf7203a5a1e9a"),
+                ("L2101518", "wfr.abbc2a2c8d524a8382e15a1dec0a5e61"),
+                ("L2101519", "wfr.ced7c8f3a8ac46d993d3d1f60509830a"),
+                ("L2101621", "wfr.42b659ae81374ee48c39e2debd769123"),
+                ("L2101622", "wfr.081a3f204d074a599517d5326c795f2c"),
+                ("L2101644", "wfr.93f2247d9f8d400db34477f72aa272b5"),
+            ]
+
+            nonlocal total_jobs_to_eval
+            total_jobs_to_eval = 1  # overwrite evaluation
+
+            for run_pair in run_pairs:
+                library_id, wfr_id = run_pair
+                wfr = wes.get_run(wfr_id=wfr_id)
+                wfl = Workflow.objects.create(
+                    wfr_name=wfr.name,
+                    type_name=WorkflowType.DRAGEN_TSO_CTDNA.value,
+                    wfr_id=wfr.id,
+                    wfv_id=wfr.workflow_version.id,
+                    version=wfr.workflow_version.version,
+                    input=wfr.input,
+                    start=wfr.time_started if wfr.time_started else wfr.time_created,
+                    output=wfr.output,
+                    end=wfr.time_stopped if wfr.time_stopped else wfr.time_modified,
+                    end_status=wfr.status,
+                    sequence_run=sqr,
+                )
+                libraryrun_srv.link_library_runs_with_workflow(library_id=library_id, workflow=wfl)
+
+        # first --
+        # - we need metadata!
+        # - populate LabMetadata tables in test db
+        from data_processors.lims.lambdas import labmetadata
+        labmetadata.scheduled_update_handler({
+            'sheets': ["2020", "2021"],
+            'truncate': False
+        }, None)
+        logger.info(f"Lab metadata count: {LabMetadata.objects.count()}")
+
+        # second --
+        # - we need to have BCL Convert workflow in db
+        # - WorkflowFactory also create related fixture sub factory SequenceRunFactory and linked them
+        mock_bcl_convert: Workflow = WorkflowFactory()
+        sqr = mock_bcl_convert.sequence_run
+        sqr.run_id = bssh_run_event['run_id']
+        sqr.instrument_run_id = bssh_run_event['instrument_run_id']
+        sqr.name = sqr.instrument_run_id
+        sqr.save()
+
+        # third --
+        # - grab workflow run from WES endpoint
+        # - sync input and output attributes to our mock BCL Convert workflow in db
+        bcl_convert_run = wes.get_run(bcl_convert_wfr_id, to_dict=True)
+        mock_bcl_convert.wfr_id = bcl_convert_wfr_id
+        mock_bcl_convert.input = json.dumps(bcl_convert_run['input'])
+        mock_bcl_convert.output = json.dumps(bcl_convert_run['output'])
+        mock_bcl_convert.save()
+
+        # Optionally we could perform deep replay
+        deep_replay()
+
+        # fourth --
+        # - replay FastqListRow update step after BCL Convert workflow succeeded
+        fastq_update_step.perform(mock_bcl_convert)
+
+        # fifth --
+        # - we also need Batch and BatchRun since workflows (jobs) are running in batch manner
+        # - we will use Batcher to create them, just like in dragen_wgs_qc_step.perform()
+        batcher = Batcher(
+            workflow=mock_bcl_convert,
+            run_step=WorkflowType.DRAGEN_TSO_CTDNA.value,
+            batch_srv=batch_srv,
+            fastq_srv=fastq_srv,
+            logger=logger
+        )
+
+        logger.info("-" * 32)
+        logger.info("PREPARE DRAGEN_TSO_CTDNA JOBS:")
+
+        job_list = dragen_tso_ctdna_step.prepare_dragen_tso_ctdna_jobs(batcher)
+
+        logger.info("-" * 32)
+        logger.info("JOB LIST JSON:")
+        logger.info(json.dumps(job_list))
+        logger.info("YOU SHOULD COPY ABOVE JSON INTO A FILE, FORMAT IT AND CHECK THAT IT LOOKS ALRIGHT")
+        self.assertIsNotNone(job_list)
+        self.assertEqual(len(job_list), total_jobs_to_eval)
+
+    @skip
+    def test_prepare_dragen_tso_ctdna_jobs_68(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_tso_ctdna_step.DragenTsoCtDnaStepIntegrationTests.test_prepare_dragen_tso_ctdna_jobs_68
+        """
+
+        # --- pick one successful BCL Convert run in development project
+
+        # 211210_A01052_0068_BH372HDMXY in PROD
+
+        # https://umccr.slack.com/archives/C8CG6K76W/p1639223305000700
+        bssh_run_event = {
+            'gds_volume_name': "bssh.acddbfda498038ed99fa94fe79523959",
+            'gds_folder_path': "/Runs/211210_A01052_0068_BH372HDMXY_r.rDEbzQ1dd0uB60d4Ix5dVQ",
+            'instrument_run_id': "211210_A01052_0068_BH372HDMXY",
+            'run_id': "r.rDEbzQ1dd0uB60d4Ix5dVQ",
+        }
+
+        # https://umccr.slack.com/archives/C8CG6K76W/p1639237411001200
+        bcl_convert_wfr_id = "wfr.eb1c64d9fdcf43488bb3f8e35ae26009"
+        total_jobs_to_eval = 9
+
+        # --- we need to rewind & replay pipeline state in the test db (like cassette tape, ya know!)
+
+        def deep_replay():
+            from data_processors.pipeline.lambdas import libraryrun
+            libraryrun.handler(bssh_run_event, None)
+
+            run_pairs = [
+                # https://umccr.slack.com/archives/C8CG6K76W/p1639293539003900
+                ("L2101498", "wfr.06f8301aacfe414b853d1a2dd1fc51ac"),
+                ("L2101499", "wfr.4ef8316d6598496da9e3736c3303e314"),
+                ("L2101500", "wfr.78517fff6cd94be3973a47bb4b03d07d"),
+                ("L2101501", "wfr.00cb43e2a93c4680a2d6ec312748f5c1"),
+                ("L2101502", "wfr.90b30d0b1ac34532b5cd98c57f594c6a"),
+                ("L2101503", "wfr.5369e306614644888e1960eff8e96454"),
+                ("L2101505", "wfr.7c2c0c4323794689aae775153be816ed"),
+                ("L2101506", "wfr.9452b3a85ea84e56ba6996df4d7123de"),
+                ("L2101520", "wfr.6f731313eace449891c3f8ba85d5d50f"),
+
+                # https://umccr.slack.com/archives/C8CG6K76W/p1639500685024300
+                ("L2101498", "wfr.24dae4f1dc814c50a73536251858758b"),
+                ("L2101499", "wfr.2c260b9a03c04342896dccd4fe965d19"),
+                ("L2101500", "wfr.bbd175bd92b74ee58eab8eb8194360c6"),
+                ("L2101501", "wfr.71474e76269c427ab3166556df98cd33"),
+                ("L2101502", "wfr.80aae1ea7fdd45d79165dcdde7157452"),
+                ("L2101503", "wfr.46afd96e0c7249bbae0734af7a8eece5"),
+                ("L2101505", "wfr.f1fbe321c4c341428a56e93a0deb6196"),
+                ("L2101506", "wfr.f05d34ff83e449c489e86d45c6e8c17b"),
+                ("L2101520", "wfr.e4e5c37b12154a499eb0a2a32d683260"),
+            ]
+
+            nonlocal total_jobs_to_eval
+            total_jobs_to_eval = 5  # overwrite evaluation
+
+            for run_pair in run_pairs:
+                library_id, wfr_id = run_pair
+                wfr = wes.get_run(wfr_id=wfr_id)
+                wfl = Workflow.objects.create(
+                    wfr_name=wfr.name,
+                    type_name=WorkflowType.DRAGEN_TSO_CTDNA.value,
+                    wfr_id=wfr.id,
+                    wfv_id=wfr.workflow_version.id,
+                    version=wfr.workflow_version.version,
+                    input=wfr.input,
+                    start=wfr.time_started if wfr.time_started else wfr.time_created,
+                    output=wfr.output,
+                    end=wfr.time_stopped if wfr.time_stopped else wfr.time_modified,
+                    end_status=wfr.status,
+                    sequence_run=sqr,
+                )
+                libraryrun_srv.link_library_runs_with_workflow(library_id=library_id, workflow=wfl)
+
+        # first --
+        # - we need metadata!
+        # - populate LabMetadata tables in test db
+        from data_processors.lims.lambdas import labmetadata
+        labmetadata.scheduled_update_handler({
+            'sheets': ["2020", "2021"],
+            'truncate': False
+        }, None)
+        logger.info(f"Lab metadata count: {LabMetadata.objects.count()}")
+
+        # second --
+        # - we need to have BCL Convert workflow in db
+        # - WorkflowFactory also create related fixture sub factory SequenceRunFactory and linked them
+        mock_bcl_convert: Workflow = WorkflowFactory()
+        sqr = mock_bcl_convert.sequence_run
+        sqr.run_id = bssh_run_event['run_id']
+        sqr.instrument_run_id = bssh_run_event['instrument_run_id']
+        sqr.name = sqr.instrument_run_id
+        sqr.save()
+
+        # third --
+        # - grab workflow run from WES endpoint
+        # - sync input and output attributes to our mock BCL Convert workflow in db
+        bcl_convert_run = wes.get_run(bcl_convert_wfr_id, to_dict=True)
+        mock_bcl_convert.wfr_id = bcl_convert_wfr_id
+        mock_bcl_convert.input = json.dumps(bcl_convert_run['input'])
+        mock_bcl_convert.output = json.dumps(bcl_convert_run['output'])
+        mock_bcl_convert.save()
+
+        # Optionally we could perform deep replay
+        deep_replay()
+
+        # fourth --
+        # - replay FastqListRow update step after BCL Convert workflow succeeded
+        fastq_update_step.perform(mock_bcl_convert)
+
+        # fifth --
+        # - we also need Batch and BatchRun since workflows (jobs) are running in batch manner
         # - we will use Batcher to create them, just like in dragen_wgs_qc_step.perform()
         batcher = Batcher(
             workflow=mock_bcl_convert,


### PR DESCRIPTION
* Filter out library_id that has been successfully run before.
  Generally, this is desirable behaviour. By then, we wish to
  rerun the whole batch, it means manual intervention to mark
  all existing workflows to be either Failed or Tainted status
  i.e. anything other than Succeeded. So, we are good with this
  filter be applied, more generally. If this work out well, we
  shall do similar to all other workflow step modules.
* See integration test cases with Run 68 and Run 70
