### PR TITLE
Added ICA pipeline emergency stop and configurable steps

### DIFF
--- a/data_processors/pipeline/services/libraryrun_srv.py
+++ b/data_processors/pipeline/services/libraryrun_srv.py
@@ -36,9 +36,14 @@ def create_library_run_from_sequence(payload: dict):
     sample_sheet_name = payload.get('sample_sheet_name', "SampleSheet.csv")
     runinfo_name = payload.get('runinfo_name', "RunInfo.xml")
 
-    samplesheet_path = gds_folder_path + os.path.sep + sample_sheet_name
-    samplesheet_json = liborca.get_samplesheet_to_json(gds_volume=gds_volume_name, samplesheet_path=samplesheet_path)
-    samplesheet_dict = json.loads(samplesheet_json)
+    try:
+        samplesheet_path = gds_folder_path + os.path.sep + sample_sheet_name
+        samplesheet_json = liborca.get_samplesheet_to_json(gds_volume_name, samplesheet_path)
+        samplesheet_dict = json.loads(samplesheet_json)
+    except ValueError as e:
+        logger.warning(f"SKIP populating LibraryRun for {instr_run_id}. It may be that {sample_sheet_name} is "
+                       f"yet to be uploaded into the run directory.")
+        return []
 
     library_run_list = []
     data_rows = samplesheet_dict['Data']

--- a/data_processors/pipeline/services/tests/test_libraryrun_srv.py
+++ b/data_processors/pipeline/services/tests/test_libraryrun_srv.py
@@ -152,7 +152,6 @@ class LibraryRunSrvIntegrationTests(PipelineIntegrationTestCase):
         stat = labmetadata.scheduled_update_handler({'event': "LibraryRunSrvIntegrationTests", 'truncate': False}, None)
         logger.info(f"{stat}")
 
-        # SEQ-II validation dataset
         gds_volume_name = "umccr-raw-sequence-data-dev"
         gds_folder_path = "/200110_A00130_0128_AHMF7VDSXX"
         sample_sheet_name = "SampleSheet-test.csv"
@@ -171,3 +170,25 @@ class LibraryRunSrvIntegrationTests(PipelineIntegrationTestCase):
         qs = LibraryRun.objects.filter(library_id="L2000001")
         # we expect 4 entries (one per lane as defined by RunInfo.xml)
         self.assertEqual(4, qs.count())
+
+    @skip
+    def test_create_library_run_from_sequence_no_samplesheet(self):
+        """
+        python manage.py test data_processors.pipeline.services.tests.test_libraryrun_srv.LibraryRunSrvIntegrationTests.test_create_library_run_from_sequence_no_samplesheet
+        """
+
+        gds_volume_name = "umccr-raw-sequence-data-dev"
+        gds_folder_path = "/200110_A00130_0128_AHMF7VDSXX"
+        sample_sheet_name = "SampleSheet-not-exist.csv"
+
+        library_run_list = libraryrun_srv.create_library_run_from_sequence({
+            'instrument_run_id': "200110_A00130_0128_AHMF7VDSXX",
+            'run_id': "",
+            'gds_folder_path': gds_folder_path,
+            'gds_volume_name': gds_volume_name,
+            'sample_sheet_name': sample_sheet_name,
+        })
+
+        self.assertEqual(0, len(library_run_list))
+        self.assertEqual(0, LibraryRun.objects.count())
+        self.assertRaises(ValueError)


### PR DESCRIPTION
* Related and partially solves Ops issues discussed in #272 #314
* Implemented SequenceRule to support emergency stop for a specified
  Run in SSM parameter store. This works in such that we intervene to
  set the parameter before Sequence status change to PendingAnalysis.
* Added Orchestrator to read static configuration step_skip_list from
  SSM parameter store. This skip step applies to the pipeline globally.
* Fixed LibraryRun population to early in the Sequence status chain and
  improved graceful handling of SampleSheet.csv not ready in run folder.
* Improved and added related test cases
