### PR TITLE
Fixed unit test in PROD for step skip list using mockito spy

### DIFF
--- a/data_processors/pipeline/orchestration/tests/test_dragen_wgs_qc_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_wgs_qc_step.py
@@ -5,7 +5,8 @@ from unittest import skip
 from django.utils.timezone import make_aware
 from libica.app import wes
 from libica.openapi import libwes
-from mockito import when
+from libumccr.aws import libssm
+from mockito import when, spy2
 
 from data_portal.models.batch import Batch
 from data_portal.models.batchrun import BatchRun
@@ -13,6 +14,7 @@ from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, La
 from data_portal.models.workflow import Workflow
 from data_portal.tests.factories import WorkflowFactory, TestConstant
 from data_processors.pipeline.domain.batch import Batcher
+from data_processors.pipeline.domain.config import ICA_WORKFLOW_PREFIX
 from data_processors.pipeline.domain.workflow import WorkflowStatus, WorkflowType
 from data_processors.pipeline.lambdas import orchestrator
 from data_processors.pipeline.orchestration import dragen_wgs_qc_step, fastq_update_step
@@ -101,6 +103,10 @@ class DragenWgsQcStepUnitTests(PipelineUnitTestCase):
         mock_labmetadata_tumor.phenotype = LabMetadataPhenotype.TUMOR.value
         mock_labmetadata_tumor.type = LabMetadataType.WGS.value
         mock_labmetadata_tumor.save()
+
+        # ignore step_skip_list
+        spy2(libssm.get_ssm_param)
+        when(libssm).get_ssm_param(f"{ICA_WORKFLOW_PREFIX}/step_skip_list").thenReturn(json.dumps([]))
 
         result = orchestrator.handler({
             'wfr_id': TestConstant.wfr_id.value,


### PR DESCRIPTION
* Typically we won't do monkey patch to mock SSM param. But
  for orchestrator step skip list, we wish not to use live
  config during test. So we mockito it and, spy2 here mean
  everything shall look up per normal except step_skip_list.