### PR TITLE
Make stringent LabMetadataRule check for workflow run

### DIFF
--- a/data_processors/pipeline/domain/workflow.py
+++ b/data_processors/pipeline/domain/workflow.py
@@ -310,16 +310,43 @@ class LabMetadataRule:
             raise LabMetadataRuleError(f"No metadata.")
         self.this_metadata = this_metadata
 
+    def must_set_workflow(self):
+        """Workflow can not be null or empty"""
+        if self.this_metadata.workflow is None or str(self.this_metadata.workflow) == "":
+            raise LabMetadataRuleError(f"Workflow is not defined.")
+        return self
+
     def must_not_manual(self):
         from data_portal.models.labmetadata import LabMetadataWorkflow
         if self.this_metadata.workflow.lower() == LabMetadataWorkflow.MANUAL.value.lower():
             raise LabMetadataRuleError(f"Workflow is set to manual.")
         return self
 
+    def must_not_qc(self):
+        """Demultiplex and run QC on FASTQ (once on ICA that includes DRAGEN alignment for better stats)"""
+        from data_portal.models.labmetadata import LabMetadataWorkflow
+        if self.this_metadata.workflow.lower() == LabMetadataWorkflow.QC.value.lower():
+            raise LabMetadataRuleError(f"Workflow is set to QC.")
+        return self
+
+    def must_not_bcl(self):
+        """Do not demultiplex, concept; keep flowcell as-is"""
+        from data_portal.models.labmetadata import LabMetadataWorkflow
+        if self.this_metadata.workflow.lower() == LabMetadataWorkflow.BCL.value.lower():
+            raise LabMetadataRuleError(f"Workflow is set to BCL.")
+        return self
+
     def must_not_ntc(self):
         from data_portal.models.labmetadata import LabMetadataPhenotype
         if self.this_metadata.phenotype.lower() == LabMetadataPhenotype.N_CONTROL.value.lower():
             raise LabMetadataRuleError(f"Negative-control sample.")
+        return self
+
+    def must_be_tumor(self):
+        """Sample Phenotype must be tumor"""
+        from data_portal.models.labmetadata import LabMetadataPhenotype
+        if self.this_metadata.phenotype.lower() != LabMetadataPhenotype.TUMOR.value.lower():
+            raise LabMetadataRuleError(f"Not tumor sample.")
         return self
 
     def must_be_wgs(self):

--- a/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/dragen_tso_ctdna_step.py
@@ -88,7 +88,13 @@ def prepare_dragen_tso_ctdna_jobs(batcher: Batcher) -> List[dict]:
         this_metadata: LabMetadata = metadata_srv.get_metadata_by_library_id(rglb)
 
         try:
-            LabMetadataRule(this_metadata).must_not_manual().must_be_cttso_ctdna()
+            LabMetadataRule(this_metadata) \
+                .must_set_workflow() \
+                .must_not_manual() \
+                .must_not_bcl() \
+                .must_not_qc() \
+                .must_be_cttso_ctdna() \
+                .must_be_tumor()
 
             BatchRule(
                 batcher=batcher,

--- a/data_processors/pipeline/orchestration/dragen_wgs_qc_step.py
+++ b/data_processors/pipeline/orchestration/dragen_wgs_qc_step.py
@@ -74,7 +74,11 @@ def prepare_dragen_wgs_qc_jobs(batcher: Batcher) -> List[dict]:
         this_metadata: LabMetadata = metadata_srv.get_metadata_by_library_id(rglb)
 
         try:
-            LabMetadataRule(this_metadata).must_not_manual().must_be_wgs()
+            LabMetadataRule(this_metadata) \
+                .must_set_workflow() \
+                .must_not_manual() \
+                .must_not_bcl() \
+                .must_be_wgs()
 
             BatchRule(
                 batcher=batcher,

--- a/data_processors/pipeline/orchestration/dragen_wts_step.py
+++ b/data_processors/pipeline/orchestration/dragen_wts_step.py
@@ -76,7 +76,13 @@ def prepare_dragen_wts_jobs(batcher: Batcher) -> List[dict]:
         this_metadata: LabMetadata = metadata_srv.get_metadata_by_library_id(rglb)
 
         try:
-            LabMetadataRule(this_metadata).must_not_manual().must_be_wts()
+            LabMetadataRule(this_metadata) \
+                .must_set_workflow() \
+                .must_not_manual() \
+                .must_not_bcl() \
+                .must_not_qc() \
+                .must_be_wts() \
+                .must_be_tumor()
 
             BatchRule(
                 batcher=batcher,

--- a/data_processors/pipeline/orchestration/tests/test_dragen_tso_ctdna_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_tso_ctdna_step.py
@@ -10,7 +10,8 @@ from mockito import when, spy2
 
 from data_portal.models.batch import Batch
 from data_portal.models.batchrun import BatchRun
-from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType, LabMetadataAssay
+from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType, LabMetadataAssay, \
+    LabMetadataWorkflow
 from data_portal.models.workflow import Workflow
 from data_portal.tests.factories import WorkflowFactory, TestConstant
 from data_processors.pipeline.domain.batch import Batcher
@@ -107,6 +108,7 @@ class DragenTsoCtDnaStepUnitTests(PipelineUnitTestCase):
         mock_labmetadata_tumor.phenotype = LabMetadataPhenotype.TUMOR.value
         mock_labmetadata_tumor.type = LabMetadataType.CT_DNA.value
         mock_labmetadata_tumor.assay = LabMetadataAssay.CT_TSO.value
+        mock_labmetadata_tumor.workflow = LabMetadataWorkflow.RESEARCH.value
         mock_labmetadata_tumor.save()
 
         # ignore step_skip_list
@@ -203,7 +205,7 @@ class DragenTsoCtDnaStepIntegrationTests(PipelineIntegrationTestCase):
         # --- pick one successful BCL Convert run
 
         bcl_convert_wfr_id = "wfr.097dc05051b44c0c8717b32d89dfcf81"  # 210429_A00130_0157_BH3N3FDSX2 in PROD
-        total_jobs_to_eval = 16
+        total_jobs_to_eval = 15
 
         # --- we need to rewind & replay pipeline state in the test db (like cassette tape, ya know!)
 

--- a/data_processors/pipeline/orchestration/tests/test_dragen_wgs_qc_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_wgs_qc_step.py
@@ -10,7 +10,7 @@ from mockito import when, spy2
 
 from data_portal.models.batch import Batch
 from data_portal.models.batchrun import BatchRun
-from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType
+from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType, LabMetadataWorkflow
 from data_portal.models.workflow import Workflow
 from data_portal.tests.factories import WorkflowFactory, TestConstant
 from data_processors.pipeline.domain.batch import Batcher
@@ -102,6 +102,7 @@ class DragenWgsQcStepUnitTests(PipelineUnitTestCase):
         mock_labmetadata_tumor.library_id = mock_library_id
         mock_labmetadata_tumor.phenotype = LabMetadataPhenotype.TUMOR.value
         mock_labmetadata_tumor.type = LabMetadataType.WGS.value
+        mock_labmetadata_tumor.workflow = LabMetadataWorkflow.CLINICAL.value
         mock_labmetadata_tumor.save()
 
         # ignore step_skip_list

--- a/data_processors/pipeline/orchestration/tests/test_dragen_wts_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_wts_step.py
@@ -7,7 +7,7 @@ from libica.app import wes
 
 from data_portal.models.batch import Batch
 from data_portal.models.batchrun import BatchRun
-from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType
+from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType, LabMetadataWorkflow
 from data_portal.models.workflow import Workflow
 from data_portal.tests.factories import WorkflowFactory
 from data_processors.pipeline.domain.batch import Batcher
@@ -89,6 +89,7 @@ class DragenWtsStepUnitTests(PipelineUnitTestCase):
         mock_labmetadata_tumor.library_id = mock_library_id
         mock_labmetadata_tumor.phenotype = LabMetadataPhenotype.TUMOR.value
         mock_labmetadata_tumor.type = LabMetadataType.WTS.value
+        mock_labmetadata_tumor.workflow = LabMetadataWorkflow.CLINICAL.value
         mock_labmetadata_tumor.save()
 
         result = dragen_wts_step.perform(mock_bcl_workflow)
@@ -123,7 +124,7 @@ class DragenWtsStepIntegrationTests(PipelineIntegrationTestCase):
         # ica workflows runs get wfr.<ID>
 
         bcl_convert_wfr_id = "wfr.8885338040b542f290c9bf6b7e0c4a36"  # from Run 171 in PROD
-        total_jobs_to_eval = 9
+        total_jobs_to_eval = 8
 
         # --- we need to rewind & replay pipeline state in the test db (like cassette tape, ya know!)
 


### PR DESCRIPTION
* This fixes running normal sample to tumor only workflow. It relies on
  LabMetadata annotation more. Validation rule evaluates meta info columns
  in order workflow, type, assay, phenotype. Skip on first violation found.
