### PR TITLE
Fixed RNAsum step skip unittest

### DIFF
--- a/data_processors/pipeline/orchestration/tests/test_rnasum_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_rnasum_step.py
@@ -97,7 +97,9 @@ class RNAsumStepUnitTests(PipelineUnitTestCase):
         self.assertIsNotNone(results)
 
         logger.info(f"{json.dumps(results)}")
-        self.assertEqual(results['submitting_subjects'][0], TestConstant.subject_id.value)
+        # self.assertEqual(results['submitting_subjects'][0], TestConstant.subject_id.value)
+        # FIXME issue #417
+        self.assertEqual(results['message'], "STEP_NOT_AUTOMATED")
 
     def test_prepare_rnasum_jobs(self):
         """


### PR DESCRIPTION
* RNAsum step is not fully automated yet and safety switch
  is turned on. Updated unittest to make sure of it.
* File it under #417 for follow up
