### PR TITLE
Updated umccrise path to be subdirectory of umccrise output directory

### DIFF
--- a/data_processors/pipeline/orchestration/rnasum_step.py
+++ b/data_processors/pipeline/orchestration/rnasum_step.py
@@ -141,7 +141,11 @@ def prepare_rnasum_jobs(this_workflow: Workflow) -> List[Dict]:
     tumor_dataset = lookup_tcga_dataset(meta=meta_tumor)
 
     # Extend umccrise directory by one additional directory that is named as '<subject_id>__<sample_name>'
-    umccrise_directory = umccrise_directory + f"{this_subject}__{meta_tumor.sample_id}"
+    if "location" in umccrise_directory.keys():
+        umccrise_directory['location'] = get_umccrise_sample_results_from_root_dir(umccrise_directory["location"],
+                                                                                   this_subject, meta_tumor.sample_id)
+    else:
+        umccrise_directory = None
 
     job = {
         "dragen_transcriptome_directory": dragen_transcriptome_directory,

--- a/data_processors/pipeline/orchestration/rnasum_step.py
+++ b/data_processors/pipeline/orchestration/rnasum_step.py
@@ -161,6 +161,17 @@ def prepare_rnasum_jobs(this_workflow: Workflow) -> List[Dict]:
     return [job]
 
 
+def get_umccrise_sample_results_from_root_dir(umccrise_directory_location: str, subject_id: str, sample_name: str) -> str:
+    """
+    Append, subject id and sample name to the umccrise_directory_location
+    :param umccrise_directory_location:
+    :param subject_id:
+    :param sample_name:
+    :return:
+    """
+    return umccrise_directory_location.rstrip("/") + "/" + f"{subject_id}__{sample_name}"
+
+
 def lookup_tcga_dataset(meta: LabMetadata):
     # TODO resolve https://github.com/umccr/data-portal-apis/issues/417
     #  Implement dynamic TCGA dataset lookup

--- a/data_processors/pipeline/orchestration/rnasum_step.py
+++ b/data_processors/pipeline/orchestration/rnasum_step.py
@@ -140,6 +140,9 @@ def prepare_rnasum_jobs(this_workflow: Workflow) -> List[Dict]:
     # Get patient specific reference dataset
     tumor_dataset = lookup_tcga_dataset(meta=meta_tumor)
 
+    # Extend umccrise directory by one additional directory that is named as '<subject_id>__<sample_name>'
+    umccrise_directory = umccrise_directory + f"{this_subject}__{meta_tumor.sample_id}"
+
     job = {
         "dragen_transcriptome_directory": dragen_transcriptome_directory,
         "umccrise_directory": umccrise_directory,

--- a/data_processors/pipeline/tools/liborca.py
+++ b/data_processors/pipeline/tools/liborca.py
@@ -151,7 +151,7 @@ def parse_arriba_workflow_output_directory(output_json: str, deep_check: bool = 
 
 def parse_umccrise_workflow_output_directory(output_json: str, deep_check: bool = True) -> Dict:
     """
-    Parse the umccrise workflow run output and get the output directory of the transcriptome workflow
+    Parse the umccrise workflow run output and get the output directory of the umccrise workflow
     :param output_json:
     :param deep_check: default to True to raise ValueError if the output section of interest is None
     :return:


### PR DESCRIPTION
As per slack conversation this morning.  

Need to move the umccrise_directory input parameter from the output directory for the umccrise workflow to a subdirectory of the umccrise output directory.

```
gds://production/analysis_data/$subject_id/umccrise/$portal_ica_workflow_instance_run/$lib_tumor__$lib_normal/
```

To 

```
gds://production/analysis_data/$subject_id/umccrise/$portal_ica_workflow_instance_run/$lib_tumor__$lib_normal/$subject_id__$sample_id
```