### PR TITLE
Updated to address S3 event processing performance issue (#143)

### DIFF
--- a/data_processors/const.py
+++ b/data_processors/const.py
@@ -26,8 +26,15 @@ class ReportHelper(ABC):
         "dragen_tso_ctdna",
     ]
 
-    # Operational limit for decompressed report json data size ~10MB
-    MAX_DECOMPRESSED_REPORT_SIZE_IN_BYTES = 11000000
+    # FIXME Report table growth rate is quite progressive; this observes over a year worth of run
+    #  since we started report data ingesting pipeline. See a quick db stats snapshot at
+    #  https://github.com/umccr/data-portal-apis/issues/143
+    #  Initially, we started ingest report data size < 150MB; then quickly reduced to 10MB. And now 1MB.
+    #  So I propose, this merit its own Report data warehousing ETL pipeline with a better fitted solution for the need.
+    #  -victor, on 20220421
+    #
+    # Operational limit for decompressed report json data size ~1MB
+    MAX_DECOMPRESSED_REPORT_SIZE_IN_BYTES = 1100000
 
     SQS_REPORT_EVENT_QUEUE_ARN = "/data_portal/backend/sqs_report_event_queue_arn"
 

--- a/data_processors/s3/lambdas/s3_event.py
+++ b/data_processors/s3/lambdas/s3_event.py
@@ -20,7 +20,7 @@ from libumccr.aws import libssm, libsqs, libs3
 from data_processors.s3 import services
 from data_processors.const import ReportHelper, S3EventRecord
 
-from aws_xray_sdk.core import xray_recorder
+# from aws_xray_sdk.core import xray_recorder
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -38,25 +38,27 @@ def handler(event: dict, context) -> Union[bool, Dict[str, int]]:
     logger.info("Start processing S3 event")
     logger.info(libjson.dumps(event))
 
-    with xray_recorder.in_subsegment("S3_EVENT_RECORDS_TRACE") as subsegment:
-        messages = event['Records']
+    # subsegment = xray_recorder.begin_subsegment("S3_EVENT_RECORDS_TRACE")
 
-        event_records_dict = parse_raw_s3_event_records(messages)
+    messages = event['Records']
 
-        s3_event_records = event_records_dict['s3_event_records']
-        report_event_records = event_records_dict['report_event_records']
+    event_records_dict = parse_raw_s3_event_records(messages)
 
-        subsegment.put_metadata('total', len(s3_event_records), 's3_event_records')
-        subsegment.put_metadata('records', s3_event_records, 's3_event_records')
+    s3_event_records = event_records_dict['s3_event_records']
+    report_event_records = event_records_dict['report_event_records']
 
-        subsegment.put_metadata('total', len(report_event_records), 'report_event_records')
-        subsegment.put_metadata('records', report_event_records, 'report_event_records')
+    # subsegment.put_metadata('total', len(s3_event_records), 's3_event_records')
+    # subsegment.put_metadata('records', s3_event_records, 's3_event_records')
+    # subsegment.put_metadata('total', len(report_event_records), 'report_event_records')
+    # subsegment.put_metadata('records', report_event_records, 'report_event_records')
 
-        results = services.sync_s3_event_records(s3_event_records)
+    results = services.sync_s3_event_records(s3_event_records)
 
-        if report_event_records:
-            queue_arn = libssm.get_ssm_param(ReportHelper.SQS_REPORT_EVENT_QUEUE_ARN)
-            libsqs.dispatch_jobs(queue_arn=queue_arn, job_list=report_event_records, fifo=False)
+    if report_event_records:
+        queue_arn = libssm.get_ssm_param(ReportHelper.SQS_REPORT_EVENT_QUEUE_ARN)
+        libsqs.dispatch_jobs(queue_arn=queue_arn, job_list=report_event_records, fifo=False)
+
+    # xray_recorder.end_subsegment()
 
     logger.info("S3 event processing complete")
 

--- a/data_processors/s3/tests/test_s3_event.py
+++ b/data_processors/s3/tests/test_s3_event.py
@@ -148,11 +148,11 @@ class S3EventUnitTests(S3EventUnitTestCase):
 
         self.assertEqual(results['removed_count'], 1)
         # We should expect the existing association removed as well
-        self.assertEqual(results['s3_lims_removed_count'], 1)
+        # self.assertEqual(results['s3_lims_removed_count'], 1)     FIXME to be removed when refactoring #343
 
         self.assertEqual(results['created_count'], 1)
         # We should expect the new association created as well
-        self.assertEqual(results['s3_lims_created_count'], 1)
+        # self.assertEqual(results['s3_lims_created_count'], 1)     FIXME to be removed when refactoring #343
         self.assertEqual(results['unsupported_count'], 0)
 
     def test_delete_non_existent_s3_object(self):


### PR DESCRIPTION
* Deactivated association links between S3 and LIMSRow
  i.e. graceful first-pass for #343 refactor
* Further reduced Report data size ingest limit to 1MB
* Commented out X-Ray recorder so that it does not even
  ping to AWS instrumentation endpoint for init boot
  i.e. "radio silent" mode that'd save few (sub) milliseconds
