### PR TITLE
add manops viewset

### DIFF
--- a/data_portal/urls.py
+++ b/data_portal/urls.py
@@ -21,6 +21,7 @@ from data_portal.viewsets.sequencerun import SequenceRunViewSet
 from data_portal.viewsets.somalier import SomalierViewSet
 from data_portal.viewsets.subject import SubjectViewSet
 from data_portal.viewsets.workflow import WorkflowViewSet
+from data_portal.viewsets.manops import ManOpsViewSet
 
 router = OptionalSlashDefaultRouter()
 router.register(r'lims', LIMSRowViewSet, basename='lims')
@@ -41,6 +42,7 @@ router.register(r'libraryrun', LibraryRunViewSet, basename='libraryrun')
 router.register(r'workflows', WorkflowViewSet, basename='workflows')
 router.register(r'pairing', PairingViewSet, basename='pairing')
 router.register(r'somalier', SomalierViewSet, basename='somalier')
+router.register(r'manops', ManOpsViewSet, basename='manops')
 
 schema_view = get_schema_view(
     openapi.Info(

--- a/data_portal/viewsets/manops.py
+++ b/data_portal/viewsets/manops.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""viewsets module
+
+NOTE:
+     This is DRF based Portal API impls.
+"""
+import logging
+import os
+from enum import Enum
+
+import boto3
+from libumccr import libjson
+from rest_framework import filters, status
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework.viewsets import ViewSet
+from rest_framework import parsers
+
+logger = logging.getLogger(__name__)
+
+from data_processors.pipeline.domain.manops import RNAsumReport
+
+
+class ManOpsViewSet(ViewSet):
+    parser_classes = [parsers.JSONParser]
+
+    def list(self, request):
+        """
+        You have hit GET /manops. This is placeholder only list endpoint. Nothing here yet.
+        Please use POST /manops endpoint and path with appropriate payload to run manual operations.
+        """
+        logger.debug(self.request.query_params)
+        return Response(data={
+            'message': self.list.__doc__
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+    def create(self, request):
+        """
+        Need more specific path, POST /manops endpoint does not exist.
+        Please hit with the correct path with appropriate payload to run the /manops endpoint.
+        """
+        return Response(data={
+            'message': self.create.__doc__
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=False, methods=['post'])
+    def run_rnasum(self, request):
+        """
+        Expected payload:
+        {
+            "wfr_id": "wfr.<umccrise_wfr_id>",
+            "subject_id": "SBJ00000",
+            "dataset": "BRCA"  See: https://github.com/umccr/RNAsum/blob/master/TCGA_projects_summary.md#pan-cancer-dataset
+        }
+        wfr_id takes precedence over subject_id
+        """
+
+        payload = request.data
+        wfr_id = payload.get("wfr_id")
+        subject_id = payload.get("subject_id")
+        dataset = payload.get("dataset")
+
+        # Validate payload
+        if not dataset or not (subject_id or wfr_id):
+            return Response(data={
+                'message': "Invalid payload. Payload required: dataset, wfr_id or subject_id "
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            # Create domain
+            rnasum_report = RNAsumReport()
+            rnasum_report.add_dataset(dataset)
+            if wfr_id:
+                rnasum_report.add_workflow(wfr_id=wfr_id)
+            else:
+                logger.info('Find latest wfr_id from subject_id latest UMCCRISE')
+                rnasum_report.add_workflow_from_subject(subject_id=subject_id)
+
+            # Triggering and response
+            report_response = rnasum_report.generate()
+            lambda_details = {
+                'payload': payload,
+                'status': report_response['StatusCode'],
+                'response': libjson.dumps(report_response),
+            }
+            logger.info(libjson.dumps(lambda_details))
+            return Response(data=lambda_details, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            logger.error(e)
+            return Response(data={'message': "INTERNAL_SERVER_ERROR"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/data_portal/viewsets/manops.py
+++ b/data_portal/viewsets/manops.py
@@ -45,7 +45,7 @@ class ManOpsViewSet(ViewSet):
         }, status=status.HTTP_400_BAD_REQUEST)
 
     @action(detail=False, methods=['post'])
-    def run_rnasum(self, request):
+    def rnasum(self, request):
         """
         Expected payload:
         {

--- a/data_portal/viewsets/manops.py
+++ b/data_portal/viewsets/manops.py
@@ -68,13 +68,16 @@ class ManOpsViewSet(ViewSet):
             }, status=status.HTTP_400_BAD_REQUEST)
 
         try:
+            logger.info('Processing event:', libjson.dumps(payload))
+
             # Create domain
             rnasum_report = RNAsumReport()
             rnasum_report.add_dataset(dataset)
             if wfr_id:
+                logger.info('Using given wfr_id')
                 rnasum_report.add_workflow(wfr_id=wfr_id)
             else:
-                logger.info('Find latest wfr_id from subject_id latest UMCCRISE')
+                logger.info('From given subject_id, find latest UMCCRISE wfr_id')
                 rnasum_report.add_workflow_from_subject(subject_id=subject_id)
 
             # Triggering and response

--- a/data_portal/viewsets/manops.py
+++ b/data_portal/viewsets/manops.py
@@ -85,7 +85,6 @@ class ManOpsViewSet(ViewSet):
             lambda_details = {
                 'payload': payload,
                 'status': report_response['StatusCode'],
-                'response': libjson.dumps(report_response),
             }
             logger.info(libjson.dumps(lambda_details))
             return Response(data=lambda_details, status=status.HTTP_200_OK)

--- a/data_portal/viewsets/tests/test_manops.py
+++ b/data_portal/viewsets/tests/test_manops.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+from data_portal.viewsets.tests import _logger
+
+
+class ManOpsViewSetTestCase(TestCase):
+
+    def test_get_api(self):
+        """
+        python manage.py test data_portal.viewsets.tests.test_manops.ManOpsViewSetTestCase.test_get_api
+        """
+        # Get metadata list
+        _logger.info('Get labmetadata API')
+        response = self.client.get('/manops/')
+        self.assertEqual(response.status_code, 400, 'Bad Request status response is expected')

--- a/data_processors/pipeline/domain/manops.py
+++ b/data_processors/pipeline/domain/manops.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""manops domain module
+
+Domain models related to Manual of Operations (MANOPS)
+
+See domain package __init__.py doc string.
+See orchestration package __init__.py doc string.
+"""
+import json
+import os
+from typing import List
+from abc import ABC, abstractmethod
+from enum import Enum
+from libumccr import aws
+from data_portal.models.workflow import Workflow
+from data_processors.pipeline.domain.workflow import WorkflowType, WorkflowStatus
+from data_processors.pipeline.services.workflow_srv import get_succeeded_by_subject_id_and_workflow_type
+import boto3
+
+
+############################################################
+# Improvement: importing from libumccr when it is available
+# Ref: https://github.com/umccr/libumccr/commit/cbf781fbd271e63c17dd45bd73751bf4807c1f6c
+
+class LambdaInvocationType(Enum):
+    EVENT = 'Event'
+    REQUEST_RESPONSE = 'RequestResponse'
+    DRY_RUN = 'DryRun'
+
+
+############################################################
+
+
+class Report(Enum):
+    RNASUM = "rnasum"
+
+    @classmethod
+    def from_value(cls, value):
+        if value == cls.RNASUM.value:
+            return cls.RNASUM
+        else:
+            raise ValueError(f"No matching type found for {value}")
+
+    @staticmethod
+    def to_list():
+        return [e.value for e in Report]
+
+
+class ReportInterface(ABC):
+
+    @abstractmethod
+    def generate(self):
+        pass
+
+
+class RNAsumReport(ReportInterface):
+    """Triggering RNAsum report via lambda"""
+
+    def __init__(self):
+        super().__init__()
+        self.wfr_id = ""
+        self.dataset = ""
+
+    def add_dataset(self, dataset: str):
+        self.dataset = dataset
+
+    def add_workflow(self, wfr_id: str):
+        self.wfr_id = wfr_id
+
+    def add_workflow_from_subject(self, subject_id: str):
+        workflow_list: List[Workflow] = get_succeeded_by_subject_id_and_workflow_type(subject_id=subject_id,
+                                                                                      workflow_type=WorkflowType.UMCCRISE
+                                                                                      )
+        # Set if value exist
+        if len(workflow_list) > 0:
+            self.wfr_id = workflow_list[0].wfr_id
+
+    def generate(self):
+        fn_name = os.getenv('MANOPS_LAMBDA', 'data-portal-api-prod-manops')
+
+        payload_json = json.dumps({
+            "event_type": Report.RNASUM.value,
+            "wfr_id": self.wfr_id,
+            "dataset": self.dataset
+        })
+
+        lambda_client = boto3.client('lambda')
+        lambda_response = lambda_client.invoke(
+            FunctionName=fn_name,
+            InvocationType=LambdaInvocationType.EVENT.value,
+            Payload=payload_json,
+        )
+
+        return lambda_response

--- a/data_processors/pipeline/domain/manops.py
+++ b/data_processors/pipeline/domain/manops.py
@@ -76,7 +76,7 @@ class RNAsumReport(ReportInterface):
             self.wfr_id = workflow_list[0].wfr_id
 
     def generate(self):
-        fn_name = os.getenv('MANOPS_LAMBDA', 'data-portal-api-prod-manops')
+        fn_name = os.getenv('MANOPS_LAMBDA', 'data-portal-api-dev-manops')
 
         payload_json = json.dumps({
             "event_type": Report.RNASUM.value,

--- a/data_processors/pipeline/domain/tests/test_manops.py
+++ b/data_processors/pipeline/domain/tests/test_manops.py
@@ -1,0 +1,48 @@
+import logging
+from data_portal.tests.factories import  LabMetadataFactory
+from data_processors.pipeline.domain.manops import ReportInterface, RNAsumReport
+from django.test import TestCase
+from data_portal.tests.factories import WorkflowFactory, Workflow, LibraryRunFactory, TestConstant, WorkflowType, \
+    WorkflowStatus
+
+logger = logging.getLogger('INFO')
+
+
+class ReportUnitTests(TestCase):
+
+    def test_abc_report(self):
+        """
+        python manage.py test data_processors.pipeline.domain.tests.test_manops.ReportUnitTests.test_abc_report
+        """
+        try:
+            _ = ReportInterface()
+        except Exception as e:
+            logger.exception(f"THIS ERROR EXCEPTION IS INTENTIONAL FOR TEST. NOT ACTUAL ERROR. \n{e}")
+        self.assertRaises(TypeError)
+
+    def test_rnasum_add_workflow_from_subject(self):
+        """
+        python manage.py test data_processors.pipeline.domain.tests.test_manops.ReportUnitTests.test_rnasum_add_workflow_from_subject
+        """
+        # Test values
+        test_subject_id = TestConstant.subject_id.value
+        test_wfr_type_name = WorkflowType.UMCCRISE
+
+        # Create Mock datas
+        mock_labmetadata = LabMetadataFactory()
+        mock_labmetadata.save()
+        mock_libraryrun = LibraryRunFactory()
+        mock_libraryrun.save()
+
+        mock_workflow: Workflow = WorkflowFactory()
+        mock_workflow.end_status = WorkflowStatus.SUCCEEDED.value
+        mock_workflow.type_name = test_wfr_type_name.value
+        mock_workflow.wfr_name = f"umccr__automated__umccrise__{test_subject_id}__L2000002__20220222abcdef"
+        mock_workflow.save()
+        mock_libraryrun.workflows.add(mock_workflow)
+        report = RNAsumReport()
+        report.add_workflow_from_subject("SBJ00001")
+        report.add_dataset("BRCA")
+
+        self.assertTrue(report.wfr_id == mock_workflow.wfr_id)
+        self.assertTrue(report.dataset == "BRCA")

--- a/data_processors/pipeline/services/workflow_srv.py
+++ b/data_processors/pipeline/services/workflow_srv.py
@@ -207,8 +207,9 @@ def get_succeeded_by_library_id_and_workflow_type(library_id: str, workflow_type
 @transaction.atomic
 def get_succeeded_by_subject_id_and_workflow_type(subject_id: str, workflow_type: WorkflowType) -> List[Workflow]:
     """
-    Get all succeeded workflow runs related to this library_id and WorkflowType. It will join call through LibraryRun
-    using library_id. It is also sorted desc by workflow end time. So, latest is always at top i.e. workflow_list[0]
+    Get all succeeded workflow runs related to this subject_id and WorkflowType. It will join call between LabMetadata,
+    LibraryRun, and Workflow to fetch the correct subject_id. It is also sorted desc by workflow id. So, latest is
+    always at top i.e. workflow_list[0]
     """
     workflow_list = list()
 
@@ -221,7 +222,7 @@ def get_succeeded_by_subject_id_and_workflow_type(subject_id: str, workflow_type
         type_name=workflow_type.value,
         end_status=WorkflowStatus.SUCCEEDED.value,
         libraryrun__library_id__in=matching_library_id_qs,
-    ).order_by('-id')
+    ).order_by('-end')
 
     if workflow_qs.exists():
         for wfl in workflow_qs.all():

--- a/serverless.yml
+++ b/serverless.yml
@@ -75,6 +75,7 @@ provider:
   environment:
     DJANGO_SETTINGS_MODULE: data_portal.settings.aws
     LAB_METADATA_SYNC_LAMBDA: ${self:service}-${sls:stage}-labmetadata_scheduled_update_processor
+    MANOPS_LAMBDA: ${self:service}-${sls:stage}-manops
 
 functions:
 


### PR DESCRIPTION
- Added `/manops/rnasum` endpoint. Trigger manops lamda from given payload. ([Structure](https://github.com/umccr/data-portal-apis/blob/0c1bf03201c4b63059ffadef0ddac21d18dd4974/data_portal/viewsets/manops.py#L50-L55))
- Added workflow service function to find workflow from subject_id. If needed, could make this available through `/workflow` api by moving it to the manager in `/data_portal/models/`
- Added `manops` lambda name as  environment variable.