### PR TITLE
Dracarys orchestrator

### DIFF
--- a/data_processors/pipeline/domain/config.py
+++ b/data_processors/pipeline/domain/config.py
@@ -17,3 +17,6 @@ SQS_UMCCRISE_QUEUE_ARN = "/data_portal/backend/sqs_umccrise_queue_arn"
 SQS_DRAGEN_WTS_QUEUE_ARN = "/data_portal/backend/sqs_dragen_wts_queue_arn"
 SQS_RNASUM_QUEUE_ARN = "/data_portal/backend/sqs_rnasum_queue_arn"
 SQS_SOMALIER_EXTRACT_QUEUE_ARN = "/data_portal/backend/sqs_somalier_extract_queue_arn"
+
+SQS_DRACARYS_QUEUE_ARN="/data_portal/backend/sqs_dracarys_queue_arn"
+S3_DRACARYS_BUCKET_NAME="/data_portal/backend/s3_dracarys_bucket_name"

--- a/data_processors/pipeline/lambdas/orchestrator.py
+++ b/data_processors/pipeline/lambdas/orchestrator.py
@@ -279,6 +279,12 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
 
         results = list()
 
+        if "DRACARYS_MULTIQC_STEP" in skiplist:
+            logger.info("Skip performing DRACARYS_MULTIQC_STEP")
+        else:
+            logger.info("Performing DRACARYS_MULTIQC_STEP")
+        results.append(dracarys_multiqc_step.perform(this_workflow))
+
         if "UMCCRISE_STEP" in skiplist:
             logger.info("Skip performing UMCCRISE_STEP")
         else:
@@ -302,3 +308,17 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
             results.append(rnasum_step.perform(this_workflow))
 
         return results
+        
+    elif this_workflow.type_name.lower() == WorkflowType.DRAGEN_TSO_CTDNA.value.lower() and \
+            this_workflow.end_status.lower() == WorkflowStatus.SUCCEEDED.value.lower():
+        logger.info("Received DRAGEN_TSO_CTDNA workflow notification")
+
+        WorkflowRule(this_workflow).must_have_output()
+
+        results = list()
+
+        if "DRACARYS_MULTIQC_STEP" in skiplist:
+            logger.info("Skip performing DRACARYS_MULTIQC_STEP")
+        else:
+            logger.info("Performing DRACARYS_MULTIQC_STEP")
+        results.append(dracarys_multiqc_step.perform(this_workflow))

--- a/data_processors/pipeline/lambdas/orchestrator.py
+++ b/data_processors/pipeline/lambdas/orchestrator.py
@@ -27,7 +27,7 @@ import logging
 from data_portal.models.workflow import Workflow
 from data_processors.pipeline.domain.config import ICA_WORKFLOW_PREFIX
 from data_processors.pipeline.services import workflow_srv
-from data_processors.pipeline.orchestration import dragen_wgs_qc_step, tumor_normal_step, google_lims_update_step, \
+from data_processors.pipeline.orchestration import dracarys_multiqc_step, dragen_wgs_qc_step, tumor_normal_step, google_lims_update_step, \
     dragen_tso_ctdna_step, fastq_update_step, dragen_wts_step, umccrise_step, rnasum_step, somalier_extract_step
 from data_processors.pipeline.domain.workflow import WorkflowType, WorkflowStatus, WorkflowRule
 from data_processors.pipeline.lambdas import workflow_update
@@ -220,6 +220,13 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
         else:
             logger.info("Performing SOMALIER_EXTRACT_STEP")
             results.append(somalier_extract_step.perform(this_workflow))
+
+
+        if "DRACARYS_MULTIQC_STEP" in skiplist:
+            logger.info("Skip performing DRACARYS_MULTIQC_STEP")
+        else:
+            logger.info("Performing DRACARYS_MULTIQC_STEP")
+        results.append(dracarys_multiqc_step.perform(this_workflow))
 
         return results
 

--- a/data_processors/pipeline/orchestration/dracarys_multiqc_step.py
+++ b/data_processors/pipeline/orchestration/dracarys_multiqc_step.py
@@ -32,14 +32,14 @@ def perform(this_workflow: Workflow):
     except KeyError as e:
         logging.info("Dracarys multiqc step didn't find expected multiqc output data. Exiting.")
         return {}
-
+    
+    jobs_list = []
 
     for multiqc_file in multiqc_files:
         presignurl = get_presign_url_for_single_file(multiqc_file)
 
         queue_arn=libssm.get_ssm_param(SQS_DRACARYS_QUEUE_ARN)
 
-        jobs_list = []
         job = {  "presign_url_json": presignurl, "output_prefix": outprefix, "target_bucket_name": libssm.get_ssm_param(S3_DRACARYS_BUCKET_NAME) }
         jobs_list.append(job) 
 
@@ -47,6 +47,9 @@ def perform(this_workflow: Workflow):
                 queue_arn=queue_arn,
                 job_list=jobs_list,
             )
+    
+    if not jobs_list:
+        return {}
 
     return {
         "dracarys_multiqc_step": jobs_list

--- a/data_processors/pipeline/orchestration/dracarys_multiqc_step.py
+++ b/data_processors/pipeline/orchestration/dracarys_multiqc_step.py
@@ -23,14 +23,17 @@ logger.setLevel(logging.INFO)
 
 def perform(this_workflow: Workflow):
     output_json = this_workflow.output
+    try:
+        lookup_keys = ['dragen_bam_out']
+        outprefix = liborca.parse_workflow_output(output_json, lookup_keys)['nameroot']
     
-    lookup_keys = ['dragen_bam_out' ]
-    outprefix = liborca.parse_workflow_output(output_json, lookup_keys)['nameroot']
- 
-    lookup_keys = ['multiqc_output_directory', 'location']
-    multiqc_output_directory = liborca.parse_workflow_output(output_json, lookup_keys)
+        lookup_keys = ['multiqc_output_directory', 'location']
+        multiqc_output_directory = liborca.parse_workflow_output(output_json, lookup_keys)
 
-    multiqc_files = collect_gds_multiqc_json_files(multiqc_output_directory['location'])
+        multiqc_files = collect_gds_multiqc_json_files(multiqc_output_directory['location'])
+    except KeyError as e:
+        logging.info("Dracarys multiqc step didn't find the keys it looked for. Exiting.")
+        return {}
 
     for multiqc_file in multiqc_files:
         presignurl = get_presign_url_for_single_file(multiqc_file)
@@ -50,7 +53,7 @@ def perform(this_workflow: Workflow):
         "dracarys_multiqc_step": jobs_list
     }
 
-    
+
 def get_presign_url_for_single_file(multiqc_file):
     path = multiqc_file.path
     volume_name = multiqc_file.volume_name

--- a/data_processors/pipeline/orchestration/dracarys_multiqc_step.py
+++ b/data_processors/pipeline/orchestration/dracarys_multiqc_step.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+from typing import List, Dict
+
+from libumccr.aws import libssm, libsqs
+from libica.openapi import libgds
+from libica.app import configuration
+#from data_processors.lims.lambdas.pierianutils import ica_gds, globals
+
+from libica.openapi.libgds import FileResponse
+from urllib.parse import urlparse
+
+from data_portal.models.labmetadata import LabMetadata
+from data_portal.models.workflow import Workflow
+from data_processors.pipeline.domain.config import SQS_UMCCRISE_QUEUE_ARN
+from data_processors.pipeline.services import metadata_srv
+from data_processors.pipeline.tools import liborca
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def perform(this_workflow: Workflow):
+    logging.warning("CALLED PERFORM")
+    output_json = this_workflow.output
+    lookup_keys = ['multiqc_output_directory', 'location']
+    multiqc_output_directory = liborca.parse_workflow_output(output_json, lookup_keys)
+
+    multiqc_files = collect_gds_multiqc_json_files(multiqc_output_directory['location'])
+
+    for multiqc_file in multiqc_files:
+        presignurl = get_presign_url_for_single_file(multiqc_file)
+        # call lambda - Q is how
+        # print(presignurl)
+
+    #TODO how do we call lambdas from here? 
+    #arn:aws:sqs:ap-southeast-2:843407916570:DracarysCdkStack-TriggerDracarysQueueBDD94255-v9akoKRrIeI6
+
+    return {
+        "None": None
+    }
+
+def get_presign_url_for_single_file(multiqc_file):
+    path = multiqc_file.path
+    volume_name = multiqc_file.volume_name
+
+    with libgds.ApiClient(configuration(libgds)) as api_client:
+        files_api = libgds.FilesApi(api_client)
+        try:
+            file_list: libgds.FileListResponse = files_api.list_files(
+                volume_name=[volume_name],
+                path=[path],
+                page_size=1000,
+                include="presignedUrl"
+            )
+
+            if len(file_list.items) != 1:
+                logger.error(f"Expected exactly one file at gds://" + volume_name + "/" + path)
+                raise FileNotFoundError
+
+            presignurl = file_list.items[0].presigned_url
+
+            # while end
+        except libgds.ApiException as e:
+            logger.error(f"Exception when calling list_files: \n{e}")    
+    return presignurl
+
+
+
+def collect_gds_multiqc_json_files(location: str):
+    multiqc_json_files = []
+    volume_name, path_ = parse_gds_path(location)
+
+    with libgds.ApiClient(configuration(libgds)) as api_client:
+        files_api = libgds.FilesApi(api_client)
+        try:
+            page_token = None
+            while True:
+                file_list: libgds.FileListResponse = files_api.list_files(
+                    volume_name=[volume_name],
+                    path=[f"{path_}/*"],
+                    page_size=1000,
+                    page_token=page_token,
+                )
+                print(file_list)
+                for item in file_list.items:
+                    file: libgds.FileResponse = item
+
+                    if file.name.endswith('multiqc_data.json'):
+                        multiqc_json_files.append(file)
+
+                page_token = file_list.next_page_token
+                if not file_list.next_page_token:
+                    break
+            # while end
+
+        except libgds.ApiException as e:
+            logger.error(f"Exception when calling list_files: \n{e}")
+    return multiqc_json_files
+
+def parse_gds_path(gds_path):
+    path_elements = gds_path.replace("gds://", "").split("/")
+    volume_name = path_elements[0]
+    path_ = f"/{'/'.join(path_elements[1:])}"
+    return volume_name, path_

--- a/data_processors/pipeline/orchestration/dracarys_multiqc_step.py
+++ b/data_processors/pipeline/orchestration/dracarys_multiqc_step.py
@@ -23,17 +23,16 @@ logger.setLevel(logging.INFO)
 
 def perform(this_workflow: Workflow):
     output_json = this_workflow.output
-    try:
-        lookup_keys = ['dragen_bam_out']
-        outprefix = liborca.parse_workflow_output(output_json, lookup_keys)['nameroot']
     
-        lookup_keys = ['multiqc_output_directory', 'location']
+    try:
+        lookup_keys = ['multiqc_output_directory']
         multiqc_output_directory = liborca.parse_workflow_output(output_json, lookup_keys)
-
+        outprefix = multiqc_output_directory['nameroot']
         multiqc_files = collect_gds_multiqc_json_files(multiqc_output_directory['location'])
     except KeyError as e:
-        logging.info("Dracarys multiqc step didn't find the keys it looked for. Exiting.")
+        logging.info("Dracarys multiqc step didn't find expected multiqc output data. Exiting.")
         return {}
+
 
     for multiqc_file in multiqc_files:
         presignurl = get_presign_url_for_single_file(multiqc_file)

--- a/data_processors/pipeline/orchestration/tests/test_dracarys_multiqc_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dracarys_multiqc_step.py
@@ -1,0 +1,122 @@
+import json
+from typing import List, Dict
+
+from django.utils.timezone import now
+from libumccr import libjson
+from unittest import skip
+from data_portal.models.workflow import Workflow
+from data_portal.tests.factories import DragenWgsQcWorkflowFactory
+from data_processors.pipeline.domain.workflow import WorkflowStatus
+from data_processors.pipeline.orchestration import dracarys_multiqc_step
+from data_processors.pipeline.tests.case import PipelineIntegrationTestCase, PipelineUnitTestCase, logger
+
+# From from wfr.0d3dea278b1c471d8316b9d5a242dd34
+mock_wgs_workflow_id = "wfr.0d3dea278b1c471d8316b9d5a242dd34"
+mock_wgs_output = json.dumps({
+  "dragen_alignment_output_directory": {
+    "basename": "L2100747__2_dragen",
+    "class": "Directory",
+    "location": "gds://development/analysis_data/SBJ00913/wgs_alignment_qc/20220312c26574d6/L2100747__2_dragen",
+    "nameext": "",
+    "nameroot": "L2100747__2_dragen",
+    "size": None
+  },
+  "dragen_bam_out": {
+    "basename": "MDX210178.bam",
+    "class": "File",
+    "http://commonwl.org/cwltool#generation": 0,
+    "location": "gds://development/analysis_data/SBJ00913/wgs_alignment_qc/20220312c26574d6/L2100747__2_dragen/MDX210178.bam",
+    "nameext": ".bam",
+    "nameroot": "MDX210178",
+    "secondaryFiles": [
+      {
+        "basename": "MDX210178.bam.bai",
+        "class": "File",
+        "http://commonwl.org/cwltool#generation": 0,
+        "location": "gds://development/analysis_data/SBJ00913/wgs_alignment_qc/20220312c26574d6/L2100747__2_dragen/MDX210178.bam.bai",
+        "nameext": ".bai",
+        "nameroot": "MDX210178.bam"
+      }
+    ],
+    "size": 85852344861
+  },
+  "multiqc_output_directory": {
+    "basename": "MDX210178_dragen_alignment_multiqc",
+    "class": "Directory",
+    "location": "gds://development/analysis_data/SBJ00913/wgs_alignment_qc/20220312c26574d6/MDX210178_dragen_alignment_multiqc",
+    "nameext": "",
+    "nameroot": "MDX210178_dragen_alignment_multiqc",
+    "size": None
+  },
+  "output_dir_gds_folder_id": "fol.40ebe209462f4ae98b6808d9fe2bff7d",
+  "output_dir_gds_session_id": "ssn.ba4412adcc03418f9f63a4bde00473a4",
+  "dracarys_output_directory": {
+    "basename": "L2100747__2_dragen_dracarys",
+    "class": "Directory",
+    "location": "gds://development/analysis_data/SBJ00913/wgs_alignment_qc/20220312c26574d6/L2100747__2_dragen_dracarys",
+    "nameext": "",
+    "nameroot": "L2100747__2_dragen_dracarys",
+    "size": None
+  }
+})
+
+
+def build_wgs_qc_mock():
+    mock_wgc_qc_workflow: Workflow = DragenWgsQcWorkflowFactory()
+    mock_wgc_qc_workflow.wfr_id = mock_wgs_workflow_id
+    mock_wgc_qc_workflow.output = mock_wgs_output
+    mock_wgc_qc_workflow.end = now()
+    mock_wgc_qc_workflow.end_status = WorkflowStatus.SUCCEEDED.value
+    mock_wgc_qc_workflow.save()
+    return mock_wgc_qc_workflow
+
+
+class DracarysMultiqcStepUnitTests(PipelineUnitTestCase):
+
+    def test_perform(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepUnitTests.test_perform
+        """
+        mock_wgs_qc_workflow = build_wgs_qc_mock()
+        # TODO mock some WHENs of libgds here
+        results = dracarys_multiqc_step.perform(mock_wgs_qc_workflow)
+        self.assertIsNotNone(results)
+
+        #logger.info(f"{json.dumps(results)}")
+        #self.assertIn('gds_path', results['dracarys_multiqc_step'][0])
+        assert True
+#    def test_prepare_dracarys_extract_jobs(self):
+#        """
+#        python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysExtractStepUnitTests.test_prepare_dracarys_extract_jobs
+#        """
+#        mock_wgs_qc_workflow = build_wgs_qc_mock()
+#
+#        job_list: List[Dict] = dracarys_multiqc_step.prepare_dracarys_extract_jobs(mock_wgs_qc_workflow)
+#        self.assertIsNotNone(job_list)
+#
+#        for job in job_list:
+#            logger.info(f"{libjson.dumps(job)}")  # NOTE libjson is intentional and part of serde test
+#            self.assertIn("dragen_bam_out", json.loads(mock_wgs_qc_workflow.output).keys())
+#            self.assertEqual(job['gds_path'], json.loads(mock_wgs_qc_workflow.output)['dragen_bam_out']['location'])
+
+
+class DracarysMultiqcStepIntegrationTests(PipelineIntegrationTestCase):
+    # integration test hit actual File or API endpoint, thus, manual run in most cases
+    # required appropriate access mechanism setup such as active aws login session
+    # uncomment @skip and hit the each test case!
+    # and keep decorated @skip after tested
+
+    #@skip
+    def test_handler(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepIntegrationTests.test_handler
+        """
+
+        mock_wgs_qc_workflow = build_wgs_qc_mock()
+        # TODO mock some WHENs of libgds here
+        results = dracarys_multiqc_step.perform(mock_wgs_qc_workflow)
+        self.assertIsNotNone(results)
+
+        #logger.info(f"{json.dumps(results)}")
+        #self.assertIn('gds_path', results['dracarys_multiqc_step'][0])
+        assert True

--- a/data_processors/pipeline/orchestration/tests/test_dracarys_multiqc_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dracarys_multiqc_step.py
@@ -80,30 +80,20 @@ class DracarysMultiqcStepUnitTests(PipelineUnitTestCase):
         python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepUnitTests.test_perform
         """
         mock_wgs_qc_workflow = build_wgs_qc_mock()
-        # TODO mock some WHENs of libgds here
-        when(dracarys_multiqc_step.perform).collect_gds_multiqc_json_files(...).thenReturn([{ "mock": "mock"}])
-        when(dracarys_multiqc_step.perform).get_presign_url_for_single_file(...).thenReturn("http://127.0.0.1")
-        when(libsqs.perform).dispatch_jobs(...).thenReturn("ok")
+        when(dracarys_multiqc_step).collect_gds_multiqc_json_files(...).thenReturn([{ "mock": "mock"}])
+        when(dracarys_multiqc_step).get_presign_url_for_single_file(...).thenReturn("http://127.0.0.1")
+        when(libsqs).dispatch_jobs(...).thenReturn("ok")
         results = dracarys_multiqc_step.perform(mock_wgs_qc_workflow)
-        self.assertIsNotNone(results)
-
-        assert True
-
+        self.assertIsNotNone(results['dracarys_multiqc_step'])
 
 
 class DracarysMultiqcStepIntegrationTests(PipelineIntegrationTestCase):
-    # integration test hit actual File or API endpoint, thus, manual run in most cases
-    # required appropriate access mechanism setup such as active aws login session
-    # uncomment @skip and hit the each test case!
-    # and keep decorated @skip after tested
-
-    #@skip
+    @skip
     def test_handler(self):
         """
         python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepIntegrationTests.test_handler
         """
 
         mock_wgs_qc_workflow = build_wgs_qc_mock()
-        # TODO mock some WHENs of libgds here
         results = dracarys_multiqc_step.perform(mock_wgs_qc_workflow)
-        self.assertIsNotNone(results)
+        self.assertIsNotNone(results['dracarys_multiqc_step'])

--- a/data_processors/pipeline/orchestration/tests/test_dracarys_multiqc_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dracarys_multiqc_step.py
@@ -102,7 +102,7 @@ class DracarysMultiqcStepIntegrationTests(PipelineIntegrationTestCase):
         results = dracarys_multiqc_step.perform(mock_wgs_qc_workflow)
         self.assertIsNotNone(results['dracarys_multiqc_step'])
 
-    #@skip
+    @skip
     def test_handler_wts(self):
         """
         python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepIntegrationTests.test_handler_wts
@@ -120,7 +120,7 @@ class DracarysMultiqcStepIntegrationTests(PipelineIntegrationTestCase):
         results = dracarys_multiqc_step.perform(mock_workflow)
         self.assertIsNotNone(results['dracarys_multiqc_step'])
 
-
+    @skip
     def test_handler_tn(self):
         """
         python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepIntegrationTests.test_handler_tn
@@ -138,17 +138,16 @@ class DracarysMultiqcStepIntegrationTests(PipelineIntegrationTestCase):
         results = dracarys_multiqc_step.perform(mock_workflow)
         self.assertIsNotNone(results['dracarys_multiqc_step'])
 
-    def test_handler_umccrise(self):
+    @skip
+    def test_handler_umccrise_nomultiqc(self):
         """
-        python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepIntegrationTests.test_handler_umccrise
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepIntegrationTests.test_handler_umccrise_nomultiqc
         """
-        # there is no multiqc step here, we in fact assume this will fail
+        # there is no multiqc step here, we in fact assume this will return empty
         test_wfr="wfr.ea2419104cbd4d8f837ff93d0d36ba99" # umccr__automated__umccrise__SBJ00915__L2100742__20220313ac60d1d2
         mock_workflow: Workflow = WorkflowFactory()
 
         wesrun = wes.get_run(test_wfr, to_dict=True)
-        
-        jsonout = (json.dumps(wesrun['output']))
         
         mock_workflow.output = json.dumps(wesrun['output'])
         mock_workflow.input = json.dumps(wesrun['input'])
@@ -156,4 +155,26 @@ class DracarysMultiqcStepIntegrationTests(PipelineIntegrationTestCase):
         
         results = dracarys_multiqc_step.perform(mock_workflow)
         self.assertDictEqual(results,{}) # empty dict apporpiate response
+
+    @skip
+    def test_handler_wgs_qc_nomultiqcloc(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepIntegrationTests.test_handler_wgs_qc_nomultiqcloc
+        """
+        # there IS multiqc in this output, but it has NO LOCATION - assume an empty response
+        test_wfr="wfr.526b30148ada4a8c9fcf0985c6a1170e" # umccr__automated__dragen_wgs_qc__210708_A00130_0166_AH7KTJDSX2__r
+        mock_workflow: Workflow = WorkflowFactory()
+
+        wesrun = wes.get_run(test_wfr, to_dict=True)
+        
+        mock_workflow.output = json.dumps(wesrun['output'])
+        mock_workflow.input = json.dumps(wesrun['input'])
+        mock_workflow.save()
+        
+        results = dracarys_multiqc_step.perform(mock_workflow)
+        
+        self.assertDictEqual(results,{}) # empty dict apporpiate response
+
+
+        
 

--- a/data_processors/pipeline/orchestration/tests/test_dracarys_multiqc_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dracarys_multiqc_step.py
@@ -4,8 +4,12 @@ from typing import List, Dict
 from django.utils.timezone import now
 from libumccr import libjson
 from libumccr.aws import libssm, libsqs
+from libica.app import wes
+
+
 from unittest import skip
 from data_portal.models.workflow import Workflow
+from data_portal.tests.factories import WorkflowFactory
 from data_portal.tests.factories import DragenWgsQcWorkflowFactory
 from data_processors.pipeline.domain.workflow import WorkflowStatus
 from data_processors.pipeline.orchestration import dracarys_multiqc_step
@@ -97,3 +101,59 @@ class DracarysMultiqcStepIntegrationTests(PipelineIntegrationTestCase):
         mock_wgs_qc_workflow = build_wgs_qc_mock()
         results = dracarys_multiqc_step.perform(mock_wgs_qc_workflow)
         self.assertIsNotNone(results['dracarys_multiqc_step'])
+
+    #@skip
+    def test_handler_wts(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepIntegrationTests.test_handler_wts
+        """
+
+        test_wfr="wfr.485aaf32336540ee839a929473708fff"
+        mock_workflow: Workflow = WorkflowFactory()
+
+        wesrun = wes.get_run(test_wfr, to_dict=True)
+                
+        mock_workflow.output = json.dumps(wesrun['output'])
+        mock_workflow.input = json.dumps(wesrun['input'])
+        mock_workflow.save()
+
+        results = dracarys_multiqc_step.perform(mock_workflow)
+        self.assertIsNotNone(results['dracarys_multiqc_step'])
+
+
+    def test_handler_tn(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepIntegrationTests.test_handler_tn
+        """
+
+        test_wfr="wfr.25f2c89ce8954d038fdbf268d7cc70c9" # umccr__automated__wgs_tumor_normal__SBJ00716__L2100751__20220312aace133e
+        mock_workflow: Workflow = WorkflowFactory()
+
+        wesrun = wes.get_run(test_wfr, to_dict=True)
+        
+        mock_workflow.output = json.dumps(wesrun['output'])
+        mock_workflow.input = json.dumps(wesrun['input'])
+        mock_workflow.save()
+        
+        results = dracarys_multiqc_step.perform(mock_workflow)
+        self.assertIsNotNone(results['dracarys_multiqc_step'])
+
+    def test_handler_umccrise(self):
+        """
+        python manage.py test data_processors.pipeline.orchestration.tests.test_dracarys_multiqc_step.DracarysMultiqcStepIntegrationTests.test_handler_umccrise
+        """
+        # there is no multiqc step here, we in fact assume this will fail
+        test_wfr="wfr.ea2419104cbd4d8f837ff93d0d36ba99" # umccr__automated__umccrise__SBJ00915__L2100742__20220313ac60d1d2
+        mock_workflow: Workflow = WorkflowFactory()
+
+        wesrun = wes.get_run(test_wfr, to_dict=True)
+        
+        jsonout = (json.dumps(wesrun['output']))
+        
+        mock_workflow.output = json.dumps(wesrun['output'])
+        mock_workflow.input = json.dumps(wesrun['input'])
+        mock_workflow.save()
+        
+        results = dracarys_multiqc_step.perform(mock_workflow)
+        self.assertDictEqual(results,{}) # empty dict apporpiate response
+


### PR DESCRIPTION
Initial dracarys orchestrator work - a dracarys_multiqc step to fire in orchestrator.py and fling multiqc jsons, if found, to the dracarys lambda (which ultimately places them inS3) see https://github.com/umccr/dracarys-to-s3-cdk

See integration tests for dracarys_multiqc_step for examples of how this works