### PR TITLE
Fixed unit test on Holmes Somalier service discovery

### DIFF
--- a/data_processors/pipeline/domain/somalier.py
+++ b/data_processors/pipeline/domain/somalier.py
@@ -98,8 +98,8 @@ class HolmesPipeline(HolmesInterface):
         self.srv_discovery_client = aws.srv_discovery_client()
         self.stepfn_client = aws.stepfn_client()
 
-        self.service_id = self.__discover_service_id()
-        self.service_attributes = self.__discover_service_attributes()
+        self.service_id = self.discover_service_id()
+        self.service_attributes = self.discover_service_attributes()
 
         self.check_steps_arn = self.service_attributes[self.CHECK_STEPS_ARN_KEY]
         self.extract_steps_arn = self.service_attributes[self.EXTRACT_STEPS_ARN_KEY]
@@ -108,7 +108,7 @@ class HolmesPipeline(HolmesInterface):
         self.execution_instance = None
         self.execution_result = None
 
-    def __discover_service_id(self) -> str:
+    def discover_service_id(self) -> str:
         fingerprint_service_id_list = list(
             filter(
                 lambda x: x.get("Name") == self.SERVICE_NAME,
@@ -121,7 +121,7 @@ class HolmesPipeline(HolmesInterface):
 
         return fingerprint_service_id_list[0].get("Id")
 
-    def __discover_service_attributes(self) -> Dict:
+    def discover_service_attributes(self) -> Dict:
         instances: List = self.srv_discovery_client.list_instances(ServiceId=self.service_id).get("Instances", None)
 
         if instances is None or len(instances) == 0:

--- a/data_processors/pipeline/lambdas/tests/test_somalier_check.py
+++ b/data_processors/pipeline/lambdas/tests/test_somalier_check.py
@@ -37,6 +37,13 @@ class SomalierCheckUnitTests(PipelineUnitTestCase):
         when(HolmesPipeline).check(...).thenReturn(mock_holmes_pipeline)
         when(mock_holmes_pipeline).poll().thenReturn(mock_holmes_pipeline)
 
+        # mockito to intercept Holmes pipeline service discovery and make it found
+        when(HolmesPipeline).discover_service_id().thenReturn("mock_holmes_fingerprint_service")
+        when(HolmesPipeline).discover_service_attributes().thenReturn({
+            "checkStepsArn": "checkStepsArn",
+            "extractStepsArn": "extractStepsArn",
+        })
+
         results = somalier_check.handler({
             "index": "gds://vol/fol/MDX00001.bam"
         }, None)

--- a/data_processors/pipeline/lambdas/tests/test_somalier_extract.py
+++ b/data_processors/pipeline/lambdas/tests/test_somalier_extract.py
@@ -39,6 +39,13 @@ class SomalierExtractUnitTests(PipelineUnitTestCase):
         when(HolmesPipeline).extract(...).thenReturn(mock_holmes_pipeline)
         when(somalier_check).handler(...).thenReturn(None)
 
+        # mockito to intercept Holmes pipeline service discovery and make it found
+        when(HolmesPipeline).discover_service_id().thenReturn("mock_holmes_fingerprint_service")
+        when(HolmesPipeline).discover_service_attributes().thenReturn({
+            "checkStepsArn": "checkStepsArn",
+            "extractStepsArn": "extractStepsArn",
+        })
+
         result = somalier_extract.handler({
             "gds_path": "gds://vol/fol/MDX123456.bam"
         }, None)


### PR DESCRIPTION
* Let Mockito to intercept Holmes pipeline discovery and
  make it found for unit test case.
* Effectively this reduces build time unit test guarding on fingerprint
  service discovery. Hence, making it optional SOA dependency on Portal.
* It will raise graceful Runtime error "Could not find the fingerprint services"
  where applicable.
