### PR TITLE
`/fastq` API Additional filters

### DIFF
--- a/data_portal/models/fastqlistrow.py
+++ b/data_portal/models/fastqlistrow.py
@@ -42,6 +42,13 @@ class FastqListRowManager(PortalBaseManager):
             qs = qs.filter(rglb__in=qs_meta)
             kwargs.pop('type')
 
+        type_ = kwargs.get('subject_id', None)
+        if type_:
+            q = self.reduce_multi_values_qor('subject_id', type_)
+            qs_meta = LabMetadata.objects.filter(q).values("library_id")
+            qs = qs.filter(rglb__in=qs_meta)
+            kwargs.pop('subject_id')
+
         return self.get_model_fields_query(qs, **kwargs)
 
 

--- a/data_portal/models/fastqlistrow.py
+++ b/data_portal/models/fastqlistrow.py
@@ -42,22 +42,22 @@ class FastqListRowManager(PortalBaseManager):
             qs = qs.filter(rglb__in=qs_meta)
             kwargs.pop('type')
 
-        type_ = kwargs.get('subject_id', None)
-        if type_:
+        subject_id = kwargs.get('subject_id', None)
+        if subject_id:
             q = self.reduce_multi_values_qor('subject_id', type_)
             qs_meta = LabMetadata.objects.filter(q).values("library_id")
             qs = qs.filter(rglb__in=qs_meta)
             kwargs.pop('subject_id')
 
-        type_ = kwargs.get('phenotype', None)
-        if type_:
+        phenotype = kwargs.get('phenotype', None)
+        if phenotype:
             q = self.reduce_multi_values_qor('phenotype', type_)
             qs_meta = LabMetadata.objects.filter(q).values("library_id")
             qs = qs.filter(rglb__in=qs_meta)
             kwargs.pop('phenotype')
 
-        type_ = kwargs.get('workflow', None)
-        if type_:
+        workflow = kwargs.get('workflow', None)
+        if workflow:
             q = self.reduce_multi_values_qor('workflow', type_)
             qs_meta = LabMetadata.objects.filter(q).values("library_id")
             qs = qs.filter(rglb__in=qs_meta)

--- a/data_portal/models/fastqlistrow.py
+++ b/data_portal/models/fastqlistrow.py
@@ -49,6 +49,20 @@ class FastqListRowManager(PortalBaseManager):
             qs = qs.filter(rglb__in=qs_meta)
             kwargs.pop('subject_id')
 
+        type_ = kwargs.get('phenotype', None)
+        if type_:
+            q = self.reduce_multi_values_qor('phenotype', type_)
+            qs_meta = LabMetadata.objects.filter(q).values("library_id")
+            qs = qs.filter(rglb__in=qs_meta)
+            kwargs.pop('phenotype')
+
+        type_ = kwargs.get('workflow', None)
+        if type_:
+            q = self.reduce_multi_values_qor('workflow', type_)
+            qs_meta = LabMetadata.objects.filter(q).values("library_id")
+            qs = qs.filter(rglb__in=qs_meta)
+            kwargs.pop('workflow')
+
         return self.get_model_fields_query(qs, **kwargs)
 
 

--- a/data_portal/models/fastqlistrow.py
+++ b/data_portal/models/fastqlistrow.py
@@ -44,21 +44,21 @@ class FastqListRowManager(PortalBaseManager):
 
         subject_id = kwargs.get('subject_id', None)
         if subject_id:
-            q = self.reduce_multi_values_qor('subject_id', type_)
+            q = self.reduce_multi_values_qor('subject_id', subject_id)
             qs_meta = LabMetadata.objects.filter(q).values("library_id")
             qs = qs.filter(rglb__in=qs_meta)
             kwargs.pop('subject_id')
 
         phenotype = kwargs.get('phenotype', None)
         if phenotype:
-            q = self.reduce_multi_values_qor('phenotype', type_)
+            q = self.reduce_multi_values_qor('phenotype', phenotype)
             qs_meta = LabMetadata.objects.filter(q).values("library_id")
             qs = qs.filter(rglb__in=qs_meta)
             kwargs.pop('phenotype')
 
         workflow = kwargs.get('workflow', None)
         if workflow:
-            q = self.reduce_multi_values_qor('workflow', type_)
+            q = self.reduce_multi_values_qor('workflow', workflow)
             qs_meta = LabMetadata.objects.filter(q).values("library_id")
             qs = qs.filter(rglb__in=qs_meta)
             kwargs.pop('workflow')

--- a/data_portal/models/tests/test_fastqlistrow.py
+++ b/data_portal/models/tests/test_fastqlistrow.py
@@ -56,3 +56,47 @@ class FastqListRowTests(TestCase):
         fqlr = results.get()
         logger.info(fqlr)
         self.assertEqual(fqlr.rglb, mock_lib_id)
+
+    def test_retrieve_by_subject_id(self):
+        """
+        python manage.py test data_portal.models.tests.test_fastqlistrow.FastqListRowTests.test_retrieve_by_subject_id
+        """
+
+        mock_lib_id = "L1234567"
+        mock_subject_id = "SBJ000001"
+
+        mock_meta: LabMetadata = LabMetadata(
+            subject_id=mock_subject_id,
+            library_id=mock_lib_id,
+            sample_id="foobar",
+            sample_name="foobar",
+            phenotype="tumor",
+            quality="good",
+            source="tissue",
+            type="WGS",
+            assay="TsqNano",
+            project_owner="foobar")
+        mock_meta.save()
+
+        mock_sequence_run: SequenceRun = SequenceRunFactory()
+
+        mock_fqlr = FastqListRow(
+            rgid=f"CTCAGAAG.AACTTGCC.4.210923_A00130_0001_BHH5JFDSX2.PRJ123456_{mock_lib_id}",
+            rgsm="PRJ123456",
+            rglb=mock_lib_id,
+            lane=1,
+            read_1="gds://volume/path_R1.fastq.gz",
+            read_2="gds://volume/path_R2.fastq.gz",
+            sequence_run=mock_sequence_run
+        )
+        mock_fqlr.save()
+
+        results = FastqListRow.objects.get_by_keyword(
+            subject_id=mock_subject_id
+        )
+
+        self.assertEqual(results.count(), 1)
+
+        fqlr = results.get()
+        logger.info(fqlr)
+        self.assertEqual(fqlr.rglb, mock_lib_id)


### PR DESCRIPTION
- Allow fastq list to be filtered based on `subjectId` , `workflow`, and `phenotype`.


Link PR: https://github.com/umccr/data-portal-client/pull/231