### PR TITLE
Accept `Content-Disposition` as header in GDS presign

### DIFF
--- a/data_portal/viewsets/gdsfile.py
+++ b/data_portal/viewsets/gdsfile.py
@@ -37,7 +37,11 @@ class GDSFileViewSet(ReadOnlyModelViewSet):
     @action(detail=True)
     def presign(self, request, pk=None):
         obj: GDSFile = self.get_object()
-        response = gds.presign_gds_file(file_id=obj.file_id, volume_name=obj.volume_name, path_=obj.path)
+
+        presigned_url_mode = request.headers.get('Content-Disposition')
+        response = gds.presign_gds_file(file_id=obj.file_id, volume_name=obj.volume_name, path_=obj.path,
+                                        presigned_url_mode=presigned_url_mode)
+
         if response[0]:
             return Response({'signed_url': response[1]})
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pymysql==1.0.2
 python-dateutil==2.8.2
 google-auth==2.16.0
 Werkzeug==2.2.3
-libica==2.1.0
+libica==2.2.0rc1
 libumccr==0.3.0
 gspread==5.7.2
 gspread-pandas==3.2.2


### PR DESCRIPTION
Accept `Content-Disposition` as header to determine `presigned_url_mode` for GDS file.

Fix #142 

To be merged after https://github.com/umccr-illumina/libica/pull/89