### PR TITLE
Updated umccrise step to take germline as input rather than its own step

### DIFF
--- a/data_processors/pipeline/lambdas/tests/test_tumor_normal.py
+++ b/data_processors/pipeline/lambdas/tests/test_tumor_normal.py
@@ -18,13 +18,13 @@ class TumorNormalUnitTests(PipelineUnitTestCase):
         mock_tumor_library_run: LibraryRun = TumorLibraryRunFactory()
 
         workflow: dict = tumor_normal.handler({
-            "subject_id": "SUBJECT_ID",
-            "sample_name_germline": "SAMPLE_NAME_GERMLINE",
-            "sample_name_somatic": "SAMPLE_NAME_SOMATIC",
-            "output_file_prefix_germline": "SAMPLEID_LIBRARYID_GERMLINE",
-            "output_file_prefix_somatic": "SAMPLEID_LIBRARYID_SOMATIC",
-            "output_directory_germline": "SAMPLEID_LIBRARYID_GERMLINE",
-            "output_directory_somatic": "SAMPLEID_LIBRARYID_SOMATIC",
+            "subject_id": "subjectId",
+            "sample_name_germline": "normalLibraryId",
+            "sample_name_somatic": "tumorLibraryId",
+            "output_file_prefix_germline": "normalSampleId",
+            "output_file_prefix_somatic": "tumorSampleId",
+            "output_directory_germline": "normalLibraryId",
+            "output_directory_somatic": "tumorLibraryId_normalLibraryId",
             "fastq_list_rows": [{
                 "rgid": "index1.index2.lane",
                 "rgsm": "sample_name",

--- a/data_processors/pipeline/lambdas/tests/test_tumor_normal.py
+++ b/data_processors/pipeline/lambdas/tests/test_tumor_normal.py
@@ -19,7 +19,12 @@ class TumorNormalUnitTests(PipelineUnitTestCase):
 
         workflow: dict = tumor_normal.handler({
             "subject_id": "SUBJECT_ID",
-            "sample_name": "SAMPLE_NAME",
+            "sample_name_germline": "SAMPLE_NAME_GERMLINE",
+            "sample_name_somatic": "SAMPLE_NAME_SOMATIC",
+            "output_file_prefix_germline": "SAMPLEID_LIBRARYID_GERMLINE",
+            "output_file_prefix_somatic": "SAMPLEID_LIBRARYID_SOMATIC",
+            "output_directory_germline": "SAMPLEID_LIBRARYID_GERMLINE",
+            "output_directory_somatic": "SAMPLEID_LIBRARYID_SOMATIC",
             "fastq_list_rows": [{
                 "rgid": "index1.index2.lane",
                 "rgsm": "sample_name",
@@ -47,9 +52,7 @@ class TumorNormalUnitTests(PipelineUnitTestCase):
                     "class": "File",
                     "location": "gds://path/to/read_2.fastq.gz"
                 }
-            }],
-            "output_file_prefix": "SAMPLEID_LIBRARYID",
-            "output_directory": "SAMPLEID_LIBRARYID"
+            }]
         }, None)
 
         logger.info("-" * 32)

--- a/data_processors/pipeline/lambdas/tests/test_umccrise.py
+++ b/data_processors/pipeline/lambdas/tests/test_umccrise.py
@@ -18,20 +18,21 @@ class UmccriseLambdaUnitTests(PipelineUnitTestCase):
         mock_tumor_library_run: LibraryRun = TumorLibraryRunFactory()
 
         workflow: dict = umccrise.handler({
-            "dragen_germline_directory": {
-                "class": "Directory",
-                "location": "gds://path/to/somatic/output/dir"
-            },
             "dragen_somatic_directory": {
                 "class": "Directory",
                 "location": "gds://path/to/germline/output/dir"
             },
-            "output_directory_name": "PRJ1234567",
-            "output_file_prefix": "PRJ1234567",
+            "dragen_germline_directory": {
+                "class": "Directory",
+                "location": "gds://path/to/somatic/output/dir"
+            },
+            "output_directory_name": f"{TestConstant.library_id_tumor.value}__{TestConstant.library_id_normal.value}",
             "subject_identifier": "SBJ01234",
-            "sample_name": "TUMOR_SAMPLE_ID",
+            "sample_name": "PRJ1234567",
             "tumor_library_id": f"{TestConstant.library_id_tumor.value}",
-            "normal_library_id": f"{TestConstant.library_id_normal.value}"
+            "normal_library_id": f"{TestConstant.library_id_normal.value}",
+            "dragen_tumor_id": "PRJ1234567",
+            "dragen_normal_id": "PRJ1234566",
         }, None)
 
         logger.info("-" * 32)

--- a/data_processors/pipeline/lambdas/tests/test_umccrise.py
+++ b/data_processors/pipeline/lambdas/tests/test_umccrise.py
@@ -18,28 +18,17 @@ class UmccriseLambdaUnitTests(PipelineUnitTestCase):
         mock_tumor_library_run: LibraryRun = TumorLibraryRunFactory()
 
         workflow: dict = umccrise.handler({
-            "dragen_somatic_directory": {
+            "dragen_germline_directory": {
                 "class": "Directory",
                 "location": "gds://path/to/somatic/output/dir"
             },
-            "fastq_list_rows_germline": [{
-                "rgid": "index1.index2.lane",
-                "rgsm": "sample_name",
-                "rglb": "UnknownLibrary",
-                "lane": 1,
-                "read_1": {
-                    "class": "File",
-                    "location": "gds://path/to/read_1.fastq.gz"
-                },
-                "read_2": {
-                    "class": "File",
-                    "location": "gds://path/to/read_2.fastq.gz"
-                }
-            }],
-            "output_directory_germline": "PRJ1234567",
-            "output_directory_umccrise": "TumorRglb__NormalRglb",
-            "output_file_prefix_germline": "PRJ1234567",
-            "subject_identifier_umccrise": "SBJ01234",
+            "dragen_somatic_directory": {
+                "class": "Directory",
+                "location": "gds://path/to/germline/output/dir"
+            },
+            "output_directory_name": "PRJ1234567",
+            "output_file_prefix": "PRJ1234567",
+            "subject_identifier": "SBJ01234",
             "sample_name": "TUMOR_SAMPLE_ID",
             "tumor_library_id": f"{TestConstant.library_id_tumor.value}",
             "normal_library_id": f"{TestConstant.library_id_normal.value}"

--- a/data_processors/pipeline/lambdas/tumor_normal.py
+++ b/data_processors/pipeline/lambdas/tumor_normal.py
@@ -65,9 +65,12 @@ def handler(event, context) -> dict:
     """event payload dict
     {
         "subject_id": "subjectId",
-        "sample_name": "tumorLibraryId",
-        "output_file_prefix": "tumorSampleId",
-        "output_directory": "tumorLibraryId_normalLibraryId",
+        "sample_name_germline": "normalLibraryId",
+        "sample_name_somatic": "tumorLibraryId",
+        "output_file_prefix_germline": "normalSampleId",
+        "output_file_prefix_somatic": "tumorSampleId",
+        "output_directory_germline": "normalLibraryId",
+        "output_directory_somatic": "tumorLibraryId_normalLibraryId",
         "fastq_list_rows": [{
             "rgid": "index1.index2.laneNo.illuminaId.sampleId_libraryId",
             "rgsm": "sampleId",
@@ -112,11 +115,15 @@ def handler(event, context) -> dict:
 
     # Extract name of sample and the fastq list rows
     subject_id = event['subject_id']
-    output_file_prefix = event['output_file_prefix']
-    output_directory = event['output_directory']
+    sample_name_germline = event['sample_name_germline']
+    sample_name_somatic = event['sample_name_somatic']
+    output_file_prefix_germline = event['output_file_prefix_germline']
+    output_file_prefix_somatic = event['output_file_prefix_somatic']
+    output_directory_germline = event['output_directory_germline']
+    output_directory_somatic = event['output_directory_somatic']
     fastq_list_rows = event['fastq_list_rows']
     tumor_fastq_list_rows = event['tumor_fastq_list_rows']
-    sample_name = event['sample_name']
+
 
     normal_library_id = fastq_list_rows[0]['rglb']
     tumor_library_id = tumor_fastq_list_rows[0]['rglb']
@@ -125,8 +132,10 @@ def handler(event, context) -> dict:
     wfl_helper = SecondaryAnalysisHelper(WorkflowType.TUMOR_NORMAL)
 
     workflow_input: dict = wfl_helper.get_workflow_input()
-    workflow_input["output_file_prefix"] = f"{output_file_prefix}"
-    workflow_input["output_directory"] = f"{output_directory}_dragen"
+    workflow_input["output_file_prefix_germline"] = f"{output_file_prefix_germline}"
+    workflow_input["output_file_prefix_somatic"] = f"{output_file_prefix_somatic}"
+    workflow_input["output_directory_germline"] = f"{output_directory_germline}_dragen_germline"
+    workflow_input["output_directory_somatic"] = f"{output_directory_somatic}_dragen_somatic"
     workflow_input["fastq_list_rows"] = fastq_list_rows
     workflow_input["tumor_fastq_list_rows"] = tumor_fastq_list_rows
 
@@ -168,7 +177,7 @@ def handler(event, context) -> dict:
 
     result = {
         'subject_id': subject_id,
-        'sample_name': sample_name,
+        'sample_name': sample_name_somatic,
         'id': workflow.id,
         'wfr_id': workflow.wfr_id,
         'wfr_name': workflow.wfr_name,

--- a/data_processors/pipeline/lambdas/tumor_normal.py
+++ b/data_processors/pipeline/lambdas/tumor_normal.py
@@ -124,7 +124,6 @@ def handler(event, context) -> dict:
     fastq_list_rows = event['fastq_list_rows']
     tumor_fastq_list_rows = event['tumor_fastq_list_rows']
 
-
     normal_library_id = fastq_list_rows[0]['rglb']
     tumor_library_id = tumor_fastq_list_rows[0]['rglb']
 

--- a/data_processors/pipeline/lambdas/umccrise.py
+++ b/data_processors/pipeline/lambdas/umccrise.py
@@ -74,7 +74,9 @@ def handler(event, context) -> dict:
         "subject_identifier": "SBJ01234",
         "sample_name": "TUMOR_SAMPLE_ID",
         "tumor_library_id": "tumor_rglb",
-        "normal_library_id": "normal_rglb"
+        "normal_library_id": "normal_rglb",
+        "dragen_tumor_id": "tumor_rgsm",
+        "dragen_normal_id": "normal_rgsm"
     }
 
     :param event:
@@ -98,8 +100,9 @@ def handler(event, context) -> dict:
     workflow_input['dragen_somatic_directory'] = event['dragen_somatic_directory']
     workflow_input['dragen_germline_directory'] = event['dragen_germline_directory']
     workflow_input['output_directory_name'] = event['output_directory_name']
-    workflow_input['output_file_prefix'] = event['output_file_prefix']
     workflow_input['subject_identifier'] = subject_id
+    workflow_input['dragen_normal_id'] = event['dragen_normal_id']
+    workflow_input['dragen_tumor_id'] = event['dragen_tumor_id']
 
     # read workflow id and version from parameter store
     workflow_id = wfl_helper.get_workflow_id()

--- a/data_processors/pipeline/lambdas/umccrise.py
+++ b/data_processors/pipeline/lambdas/umccrise.py
@@ -66,24 +66,12 @@ def handler(event, context) -> dict:
             "class": "Directory",
             "location": "gds://path/to/somatic/output/dir"
         },
-        "fastq_list_rows_germline": [{
-            "rgid": "index1.index2.laneNo.illuminaId.sampleId_libraryId",
-            "rgsm": "sampleId",
-            "rglb": "libraryId",
-            "lane": int,
-            "read_1": {
-              "class": "File",
-              "location": "gds://path/to/read_1.fastq.gz"
-            },
-            "read_2": {
-              "class": "File",
-              "location": "gds://path/to/read_2.fastq.gz"
-            }
-        }],
-        "output_directory_germline": "PRJ1234567",
-        "output_directory_umccrise": "TumorRglb__NormalRglb",
-        "output_file_prefix_germline": "PRJ1234567",
-        "subject_identifier_umccrise": "SBJ01234",
+        "dragen_germline_directory": {
+            "class": "Directory",
+            "location": "gds://path/to/germline/output/dir"
+        },
+        "output_directory_name": "TumorRglb__NormalRglb",
+        "subject_identifier": "SBJ01234",
         "sample_name": "TUMOR_SAMPLE_ID",
         "tumor_library_id": "tumor_rglb",
         "normal_library_id": "normal_rglb"
@@ -97,7 +85,7 @@ def handler(event, context) -> dict:
     logger.info(f"Start processing {WorkflowType.UMCCRISE.name} event")
     logger.info(libjson.dumps(event))
 
-    subject_id = event['subject_identifier_umccrise']
+    subject_id = event['subject_identifier']
     sample_name = event['sample_name']  # TUMOR_SAMPLE_ID
     tumor_library_id = event['tumor_library_id']
     normal_library_id = event['normal_library_id']
@@ -108,11 +96,10 @@ def handler(event, context) -> dict:
     # Read input template from parameter store
     workflow_input: dict = wfl_helper.get_workflow_input()
     workflow_input['dragen_somatic_directory'] = event['dragen_somatic_directory']
-    workflow_input['fastq_list_rows_germline'] = event['fastq_list_rows_germline']
-    workflow_input['output_directory_germline'] = event['output_directory_germline']
-    workflow_input['output_directory_umccrise'] = event['output_directory_umccrise']
-    workflow_input['output_file_prefix_germline'] = event['output_file_prefix_germline']
-    workflow_input['subject_identifier_umccrise'] = subject_id
+    workflow_input['dragen_germline_directory'] = event['dragen_germline_directory']
+    workflow_input['output_directory_name'] = event['output_directory_name']
+    workflow_input['output_file_prefix'] = event['output_file_prefix']
+    workflow_input['subject_identifier'] = subject_id
 
     # read workflow id and version from parameter store
     workflow_id = wfl_helper.get_workflow_id()

--- a/data_processors/pipeline/orchestration/tests/test_tumor_normal_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_tumor_normal_step.py
@@ -54,7 +54,7 @@ def build_tn_mock():
     mock_flr_normal = FastqListRow()
     mock_flr_normal.lane = 1
     mock_flr_normal.rglb = TestConstant.library_id_normal.value
-    mock_flr_normal.rgsm = TestConstant.sample_id.value
+    mock_flr_normal.rgsm = "PRJ210000"
     mock_flr_normal.rgid = f"AACTCACC.1.350702_A00130_0137_AH5KMHDSXY.{mock_flr_normal.rgsm}_{mock_flr_normal.rglb}"
     mock_flr_normal.read_1 = tn_mock_normal_read_1
     mock_flr_normal.save()
@@ -147,6 +147,9 @@ class TumorNormalStepUnitTests(PipelineUnitTestCase):
         self.assertEqual(job_dict['subject_id'], tn_mock_subject_id)
         self.assertEqual(job_dict['fastq_list_rows'][0]['rglb'], TestConstant.library_id_normal.value)
         self.assertEqual(job_dict['fastq_list_rows'][0]['read_1']['location'], tn_mock_normal_read_1)
+        # strongly assert the following keys present to detect workflow input binding contract changes
+        self.assertIn("output_directory_somatic", job_dict.keys())
+        self.assertIn("output_directory_germline", job_dict.keys())
 
     def test_prepare_tumor_normal_jobs_issue_475_no_skip(self):
         """

--- a/data_processors/pipeline/orchestration/tests/test_umccrise_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_umccrise_step.py
@@ -23,9 +23,9 @@ mock_tn_output = json.dumps({
         "size": None
     },
     "dragen_germline_output_directory": {
-        "basename": f"{TestConstant.library_id_normal.value}_{TestConstant.library_id_tumor.value}_dragen",
+        "basename": f"{TestConstant.library_id_normal.value}_{TestConstant.library_id_normal.value}_dragen",
         "class": "Directory",
-        "location": f"gds://vol/analysis_data/{mock_tn_subject_id}/wgs_tumor_normal/20310102aa4f9099/{TestConstant.library_id_normal.value}_{TestConstant.library_id_tumor.value}_dragen",
+        "location": f"gds://vol/analysis_data/{mock_tn_subject_id}/wgs_tumor_normal/20310102aa4f9099/{TestConstant.library_id_normal.value}_dragen",
         "nameext": "",
         "nameroot": "",
         "size": None
@@ -209,7 +209,8 @@ class UmccriseStepIntegrationTests(PipelineIntegrationTestCase):
         """
 
         # don't have a good wgs_tumor_normal run in DEV yet, this is from PROD
-        somatic_workflow_id = "wfr.f472a00d6f45421bb8637e87531e2c66"
+        # FIXME - added in a somatic+germline workflow run from dev
+        somatic_workflow_id = "wfr.5616c72c82e442f78f0f9f0d6441219e"
 
         #  ---
 

--- a/data_processors/pipeline/orchestration/tests/test_umccrise_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_umccrise_step.py
@@ -122,7 +122,7 @@ class UmccriseStepUnitTests(PipelineUnitTestCase):
 
         for job in job_list:
             logger.info(f"\n{libjson.dumps(job)}")  # NOTE libjson is intentional and part of ser/deser test
-            self.assertIn("output_directory_umccrise", job.keys())
+            self.assertIn("output_directory_name", job.keys())
 
     def test_get_fastq_list_rows_from_somatic_workflow_input(self):
         """

--- a/data_processors/pipeline/orchestration/tests/test_umccrise_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_umccrise_step.py
@@ -15,17 +15,17 @@ mock_tn_subject_id = "SBJ00001"
 
 mock_tn_output = json.dumps({
     "dragen_somatic_output_directory": {
-        "basename": f"{TestConstant.library_id_normal.value}_{TestConstant.library_id_tumor.value}_dragen",
+        "basename": f"{TestConstant.library_id_tumor.value}_{TestConstant.library_id_normal.value}_dragen_somatic",
         "class": "Directory",
-        "location": f"gds://vol/analysis_data/{mock_tn_subject_id}/wgs_tumor_normal/20310102aa4f9099/{TestConstant.library_id_normal.value}_{TestConstant.library_id_tumor.value}_dragen",
+        "location": f"gds://vol/analysis_data/{mock_tn_subject_id}/wgs_tumor_normal/20310102aa4f9099/{TestConstant.library_id_tumor.value}_{TestConstant.library_id_normal.value}_dragen_somatic",
         "nameext": "",
         "nameroot": "",
         "size": None
     },
     "dragen_germline_output_directory": {
-        "basename": f"{TestConstant.library_id_normal.value}_{TestConstant.library_id_normal.value}_dragen",
+        "basename": f"{TestConstant.library_id_normal.value}_dragen_germline",
         "class": "Directory",
-        "location": f"gds://vol/analysis_data/{mock_tn_subject_id}/wgs_tumor_normal/20310102aa4f9099/{TestConstant.library_id_normal.value}_dragen",
+        "location": f"gds://vol/analysis_data/{mock_tn_subject_id}/wgs_tumor_normal/20310102aa4f9099/{TestConstant.library_id_normal.value}_dragen_germline",
         "nameext": "",
         "nameroot": "",
         "size": None
@@ -53,7 +53,7 @@ mock_tn_input = json.dumps({
         {
             "rgid": f"ATGAGGCC.CAATTAAC.4.310101_A00130_0001_BHWLGFDSX2.PRJ310197_{TestConstant.library_id_tumor.value}",
             "rglb": f"{TestConstant.library_id_tumor.value}",
-            "rgsm": "PRJ310197",
+            "rgsm": f"{TestConstant.sample_id.value}",
             "lane": 4,
             "read_1": {
                 "class": "File",
@@ -205,11 +205,12 @@ class UmccriseStepIntegrationTests(PipelineIntegrationTestCase):
     @skip
     def test_prepare_umccrise_jobs(self):
         """
+        unset ICA_ACCESS_TOKEN
+        export AWS_PROFILE=dev
         python manage.py test data_processors.pipeline.orchestration.tests.test_umccrise_step.UmccriseStepIntegrationTests.test_prepare_umccrise_jobs
         """
 
-        # don't have a good wgs_tumor_normal run in DEV yet, this is from PROD
-        # FIXME - added in a somatic+germline workflow run from dev
+        # a somatic+germline workflow run from DEV
         somatic_workflow_id = "wfr.5616c72c82e442f78f0f9f0d6441219e"
 
         #  ---

--- a/data_processors/pipeline/orchestration/tests/test_umccrise_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_umccrise_step.py
@@ -22,6 +22,14 @@ mock_tn_output = json.dumps({
         "nameroot": "",
         "size": None
     },
+    "dragen_germline_output_directory": {
+        "basename": f"{TestConstant.library_id_normal.value}_{TestConstant.library_id_tumor.value}_dragen",
+        "class": "Directory",
+        "location": f"gds://vol/analysis_data/{mock_tn_subject_id}/wgs_tumor_normal/20310102aa4f9099/{TestConstant.library_id_normal.value}_{TestConstant.library_id_tumor.value}_dragen",
+        "nameext": "",
+        "nameroot": "",
+        "size": None
+    }
 })
 
 mock_tn_input = json.dumps({

--- a/data_processors/pipeline/orchestration/tumor_normal_step.py
+++ b/data_processors/pipeline/orchestration/tumor_normal_step.py
@@ -238,6 +238,7 @@ def create_tn_job(tumor_fastq_list_rows: List[FastqListRow], normal_fastq_list_r
     tumor_library_id = tumor_fastq_list_rows[0].rglb
     tumor_sample_name = tumor_fastq_list_rows[0].rgsm
     normal_library_id = normal_fastq_list_rows[0].rglb
+    normal_sample_name = normal_fastq_list_rows[0].rgsm
     fqlr = pd.DataFrame([fq_list_row.to_dict() for fq_list_row in normal_fastq_list_rows]).to_dict(orient="records")
     t_fqlr = pd.DataFrame([fq_list_row.to_dict() for fq_list_row in tumor_fastq_list_rows]).to_dict(orient="records")
 
@@ -246,9 +247,12 @@ def create_tn_job(tumor_fastq_list_rows: List[FastqListRow], normal_fastq_list_r
         "subject_id": subject_id,
         "fastq_list_rows": fqlr,
         "tumor_fastq_list_rows": t_fqlr,
-        "output_file_prefix": f"{tumor_sample_name}",
-        "output_directory": f"{tumor_library_id}_{normal_library_id}",
-        "sample_name": tumor_library_id
+        "output_file_prefix_germline": f"{normal_sample_name}",
+        "output_file_prefix_somatic": f"{tumor_sample_name}",
+        "output_directory_germline": f"{normal_library_id}",
+        "output_directory_somatic": f"{tumor_library_id}_{normal_library_id}",
+        "sample_name_germline": normal_library_id,
+        "sample_name_somatic": tumor_library_id
     }
 
     return job_dict

--- a/data_processors/pipeline/orchestration/tumor_normal_step.py
+++ b/data_processors/pipeline/orchestration/tumor_normal_step.py
@@ -236,9 +236,11 @@ def prepare_tumor_normal_jobs(meta_list: List[LabMetadata]) -> (List, List, List
 def create_tn_job(tumor_fastq_list_rows: List[FastqListRow], normal_fastq_list_rows: List[FastqListRow], subject_id):
     # Get tumor sample name
     tumor_library_id = tumor_fastq_list_rows[0].rglb
-    tumor_sample_name = tumor_fastq_list_rows[0].rgsm
+    tumor_sample_id = tumor_fastq_list_rows[0].rgsm
+
     normal_library_id = normal_fastq_list_rows[0].rglb
-    normal_sample_name = normal_fastq_list_rows[0].rgsm
+    normal_sample_id = normal_fastq_list_rows[0].rgsm
+
     fqlr = pd.DataFrame([fq_list_row.to_dict() for fq_list_row in normal_fastq_list_rows]).to_dict(orient="records")
     t_fqlr = pd.DataFrame([fq_list_row.to_dict() for fq_list_row in tumor_fastq_list_rows]).to_dict(orient="records")
 
@@ -247,8 +249,8 @@ def create_tn_job(tumor_fastq_list_rows: List[FastqListRow], normal_fastq_list_r
         "subject_id": subject_id,
         "fastq_list_rows": fqlr,
         "tumor_fastq_list_rows": t_fqlr,
-        "output_file_prefix_germline": f"{normal_sample_name}",
-        "output_file_prefix_somatic": f"{tumor_sample_name}",
+        "output_file_prefix_germline": f"{normal_sample_id}",
+        "output_file_prefix_somatic": f"{tumor_sample_id}",
         "output_directory_germline": f"{normal_library_id}",
         "output_directory_somatic": f"{tumor_library_id}_{normal_library_id}",
         "sample_name_germline": normal_library_id,

--- a/data_processors/pipeline/orchestration/umccrise_step.py
+++ b/data_processors/pipeline/orchestration/umccrise_step.py
@@ -31,7 +31,7 @@ def perform(this_workflow: Workflow):
 
     submitting_subjects = []
     for job in job_list:
-        submitting_subjects.append(job['subject_identifier_umccrise'])
+        submitting_subjects.append(job['subject_identifier'])
 
     return {
         "submitting_subjects": submitting_subjects
@@ -80,8 +80,8 @@ def prepare_umccrise_jobs(this_workflow: Workflow) -> List[Dict]:
     job = {
         "dragen_somatic_directory": dragen_somatic_directory,
         "dragen_germline_directory": dragen_germline_directory,
-        "output_directory_umccrise": f"{tumor_rglb}__{normal_rglb}",
-        "subject_identifier_umccrise": meta_tumor.subject_id,
+        "output_directory_name": f"{tumor_rglb}__{normal_rglb}",
+        "subject_identifier": meta_tumor.subject_id,
         "sample_name": meta_tumor.sample_id,
         "tumor_library_id": tumor_rglb,
         "normal_library_id": normal_rglb

--- a/data_processors/pipeline/orchestration/umccrise_step.py
+++ b/data_processors/pipeline/orchestration/umccrise_step.py
@@ -64,7 +64,10 @@ def prepare_umccrise_jobs(this_workflow: Workflow) -> List[Dict]:
 
     # Get tumor and normal library names for umccrise outputs
     normal_rglb = fqlr_germline[0]['rglb']
+    normal_rgsm = fqlr_germline[0]['rgsm']
+
     tumor_rglb = fqlr_tumor[0]['rglb']
+    tumor_rgsm = fqlr_tumor[0]['rgsm']
 
     # Get metadata for both tumor and normal libraries
     meta_normal: LabMetadata = metadata_srv.get_metadata_by_library_id(normal_rglb)
@@ -84,7 +87,9 @@ def prepare_umccrise_jobs(this_workflow: Workflow) -> List[Dict]:
         "subject_identifier": meta_tumor.subject_id,
         "sample_name": meta_tumor.sample_id,
         "tumor_library_id": tumor_rglb,
-        "normal_library_id": normal_rglb
+        "normal_library_id": normal_rglb,
+        "dragen_tumor_id": tumor_rgsm,
+        "dragen_normal_id": normal_rgsm,
     }
 
     return [job]

--- a/data_processors/pipeline/orchestration/umccrise_step.py
+++ b/data_processors/pipeline/orchestration/umccrise_step.py
@@ -56,13 +56,11 @@ def prepare_umccrise_jobs(this_workflow: Workflow) -> List[Dict]:
 
     # Get the dragen somatic output directory location
     dragen_somatic_directory = liborca.parse_somatic_workflow_output_directory(this_workflow.output)
+    dragen_germline_directory = liborca.parse_germline_workflow_output_directory(this_workflow.output)
 
     # Get fastq list rows for the germline sample
     # We also collect the fastq list rows for the tumor sample, so we can do some metadata checks
     fqlr_germline, fqlr_tumor = get_fastq_list_rows_from_somatic_workflow_input(this_workflow.input)
-
-    # Get normal sample name for naming germline outputs
-    normal_rgsm = fqlr_germline[0]['rgsm']
 
     # Get tumor and normal library names for umccrise outputs
     normal_rglb = fqlr_germline[0]['rglb']
@@ -81,10 +79,8 @@ def prepare_umccrise_jobs(this_workflow: Workflow) -> List[Dict]:
 
     job = {
         "dragen_somatic_directory": dragen_somatic_directory,
-        "fastq_list_rows_germline": fqlr_germline,
-        "output_directory_germline": normal_rgsm,
+        "dragen_germline_directory": dragen_germline_directory,
         "output_directory_umccrise": f"{tumor_rglb}__{normal_rglb}",
-        "output_file_prefix_germline": normal_rgsm,
         "subject_identifier_umccrise": meta_tumor.subject_id,
         "sample_name": meta_tumor.sample_id,
         "tumor_library_id": tumor_rglb,

--- a/data_processors/pipeline/tools/liborca.py
+++ b/data_processors/pipeline/tools/liborca.py
@@ -106,9 +106,27 @@ def parse_somatic_workflow_output_directory(output_json: str, deep_check: bool =
     dragen_somatic_output_directory = parse_workflow_output(output_json, lookup_keys)
 
     if deep_check and dragen_somatic_output_directory is None:
-        raise ValueError("Could not find a dragen somatic output directory from the somatic workflow")
+        raise ValueError("Could not find a dragen somatic output directory from the somatic+germline workflow")
 
     return dragen_somatic_output_directory
+
+
+def parse_germline_workflow_output_directory(output_json: str, deep_check: bool = True) -> Dict:
+    """
+    Parse the germline workflow run output and get the output directory of the germline workflow
+    :param output_json:
+    :param deep_check: default to True to raise ValueError if the output section of interest is None
+    :return:
+    """
+
+    lookup_keys = ['main/dragen_germline_output_directory', 'dragen_germline_output_directory']
+
+    dragen_germline_output_directory = parse_workflow_output(output_json, lookup_keys)
+
+    if deep_check and dragen_germline_output_directory is None:
+        raise ValueError("Could not find a dragen germline output directory from the somatic+germline workflow")
+
+    return dragen_germline_output_directory
 
 
 def parse_transcriptome_workflow_output_directory(output_json: str, deep_check: bool = True) -> Dict:

--- a/data_processors/pipeline/tools/tests/test_liborca.py
+++ b/data_processors/pipeline/tools/tests/test_liborca.py
@@ -120,9 +120,9 @@ class LibOrcaUnitTests(PipelineUnitTestCase):
         """
         mock_tn_output = json.dumps({
             "dragen_somatic_output_directory": {
-                "basename": "L0000001_L0000002_dragen",
+                "basename": "L0000002_L0000001_dragen_somatic",
                 "class": "Directory",
-                "location": "gds://vol/analysis_data/SBJ00001/wgs_tumor_normal/20211208aa4f9099/L0000001_L0000002_dragen",
+                "location": "gds://vol/analysis_data/SBJ00001/wgs_tumor_normal/20211208aa4f9099/L0000002_L0000001_dragen_somatic",
                 "nameext": "",
                 "nameroot": "",
                 "size": None
@@ -133,7 +133,7 @@ class LibOrcaUnitTests(PipelineUnitTestCase):
         logger.info("-" * 32)
         logger.info(f"parse_somatic_workflow_output_directory: {json.dumps(result)}")
 
-        self.assertEqual(result['basename'], "L0000001_L0000002_dragen")
+        self.assertEqual(result['basename'], "L0000002_L0000001_dragen_somatic")
         self.assertEqual(result['class'], "Directory")
 
     def test_parse_somatic_workflow_output_directory_none(self):
@@ -148,6 +148,28 @@ class LibOrcaUnitTests(PipelineUnitTestCase):
         except Exception as e:
             logger.exception(f"THIS ERROR EXCEPTION IS INTENTIONAL FOR TEST. NOT ACTUAL ERROR. \n{e}")
         self.assertRaises(ValueError)
+
+    def test_parse_germline_workflow_output_directory(self):
+        """
+        python manage.py test data_processors.pipeline.tools.tests.test_liborca.LibOrcaUnitTests.test_parse_germline_workflow_output_directory
+        """
+        mock_tn_output = json.dumps({
+            "dragen_germline_output_directory": {
+                "basename": "L0000001_dragen_germline",
+                "class": "Directory",
+                "location": "gds://vol/analysis_data/SBJ00001/wgs_tumor_normal/20211208aa4f9099/L0000001_dragen_germline",
+                "nameext": "",
+                "nameroot": "",
+                "size": None
+            },
+        })
+        result: dict = liborca.parse_germline_workflow_output_directory(mock_tn_output)
+
+        logger.info("-" * 32)
+        logger.info(f"parse_germline_workflow_output_directory: {json.dumps(result)}")
+
+        self.assertEqual(result['basename'], "L0000001_dragen_germline")
+        self.assertEqual(result['class'], "Directory")
 
     def test_parse_bcl_convert_output(self):
         """
@@ -540,6 +562,8 @@ class LibOrcaIntegrationTests(PipelineIntegrationTestCase):
     @skip
     def test_parse_somatic_workflow_output_directory(self):
         """
+        unset ICA_ACCESS_TOKEN
+        export AWS_PROFILE=prod
         python manage.py test data_processors.pipeline.tools.tests.test_liborca.LibOrcaIntegrationTests.test_parse_somatic_workflow_output_directory
         """
 
@@ -554,6 +578,25 @@ class LibOrcaIntegrationTests(PipelineIntegrationTestCase):
 
         self.assertIn("class", dragen_somatic_output_directory.keys())
         self.assertEqual(dragen_somatic_output_directory['class'], "Directory")
+
+    @skip
+    def test_parse_germline_workflow_output_directory(self):
+        """
+        unset ICA_ACCESS_TOKEN
+        export AWS_PROFILE=dev
+        python manage.py test data_processors.pipeline.tools.tests.test_liborca.LibOrcaIntegrationTests.test_parse_germline_workflow_output_directory
+        """
+
+        wfr_id = "wfr.5616c72c82e442f78f0f9f0d6441219e"  # in DEV
+
+        wfl_run = wes.get_run(wfr_id)
+
+        dragen_germline_output_directory = liborca.parse_germline_workflow_output_directory(json.dumps(wfl_run.output))
+
+        logger.info(f"\n{dragen_germline_output_directory}")
+
+        self.assertIn("class", dragen_germline_output_directory.keys())
+        self.assertEqual(dragen_germline_output_directory['class'], "Directory")
 
     @skip
     def test_parse_umccrise_workflow_output_directory(self):

--- a/docs/pipeline/automation/tumor_normal.md
+++ b/docs/pipeline/automation/tumor_normal.md
@@ -5,7 +5,7 @@
 We can re-enter the Pipeline from _some_ Tumor Normal step as follows.
 
 _Step 1)_
-- To prepare event payload JSON as required in [Lambda payload schema](https://github.com/umccr/data-portal-apis/blob/dev/data_processors/pipeline/lambdas/tumor_normal.py#L64-L104)
+- To prepare event payload JSON as required in [Lambda payload schema](https://github.com/umccr/data-portal-apis/blob/dev/data_processors/pipeline/lambdas/tumor_normal.py#L64-L102)
   - _Attached [tumor_normal_payload.json](tumor_normal_payload.json) here for convenience_
 
 _Step 2)_

--- a/docs/pipeline/automation/tumor_normal_payload.json
+++ b/docs/pipeline/automation/tumor_normal_payload.json
@@ -1,8 +1,11 @@
 {
   "subject_id": "subjectId",
-  "sample_name": "tumorLibraryId",
-  "output_file_prefix": "tumorSampleId",
-  "output_directory": "tumorLibraryId_normalLibraryId",
+  "sample_name_germline": "normalLibraryId",
+  "sample_name_somatic": "tumorLibraryId",
+  "output_file_prefix_germline": "normalSampleId",
+  "output_file_prefix_somatic": "tumorSampleId",
+  "output_directory_germline": "normalLibraryId",
+  "output_directory_somatic": "tumorLibraryId_normalLibraryId",
   "fastq_list_rows": [
     {
       "rgid": "index1.index2.laneNo.illuminaId.sampleId_libraryId",

--- a/docs/pipeline/automation/umccrise.md
+++ b/docs/pipeline/automation/umccrise.md
@@ -7,7 +7,7 @@ _a.k.a. umccr cancer report workflow_
 We can re-enter the Pipeline from _some_ umccrise step as follows.
 
 _Step 1)_
-- To prepare event payload JSON as required in [Lambda payload schema](https://github.com/umccr/data-portal-apis/blob/dev/data_processors/pipeline/lambdas/umccrise.py#L63-L90)
+- To prepare event payload JSON as required in [Lambda payload schema](https://github.com/umccr/data-portal-apis/blob/dev/data_processors/pipeline/lambdas/umccrise.py#L63-L80)
   - _Attached [umccrise_payload.json](umccrise_payload.json) here for convenience_
 
 _Step 2)_

--- a/docs/pipeline/automation/umccrise_payload.json
+++ b/docs/pipeline/automation/umccrise_payload.json
@@ -3,27 +3,15 @@
     "class": "Directory",
     "location": "gds://path/to/somatic/output/dir"
   },
-  "fastq_list_rows_germline": [
-    {
-      "rgid": "index1.index2.laneNo.illuminaId.sampleId_libraryId",
-      "rgsm": "sampleId",
-      "rglb": "libraryId",
-      "lane": 1,
-      "read_1": {
-        "class": "File",
-        "location": "gds://path/to/read_1.fastq.gz"
-      },
-      "read_2": {
-        "class": "File",
-        "location": "gds://path/to/read_2.fastq.gz"
-      }
-    }
-  ],
-  "output_directory_germline": "PRJ1234567",
-  "output_directory_umccrise": "TumorRglb__NormalRglb",
-  "output_file_prefix_germline": "PRJ1234567",
-  "subject_identifier_umccrise": "SBJ01234",
+  "dragen_germline_directory": {
+    "class": "Directory",
+    "location": "gds://path/to/germline/output/dir"
+  },
+  "output_directory_name": "TumorRglb__NormalRglb",
+  "subject_identifier": "SBJ01234",
   "sample_name": "TUMOR_SAMPLE_ID",
   "tumor_library_id": "tumor_rglb",
-  "normal_library_id": "normal_rglb"
+  "normal_library_id": "normal_rglb",
+  "dragen_tumor_id": "tumor_rgsm",
+  "dragen_normal_id": "normal_rgsm"
 }


### PR DESCRIPTION
Relates to https://github.com/umccr/infrastructure/pull/284

dragen somatic now runs dragen somatic + germline pipeline

umccrise step now takes dragen germline directory output as input rather than running germline as its own step.