### PR TITLE
Implemented LIMS and Metadata aggregation endpoints

### DIFF
--- a/data_portal/models/labmetadata.py
+++ b/data_portal/models/labmetadata.py
@@ -2,6 +2,7 @@ import logging
 
 from django.db import models, connection
 from django.db.models import QuerySet, Value
+from django.db.models.aggregates import Count
 from django.db.models.functions import Concat
 
 from data_portal.models.base import PortalBaseModel, PortalBaseManager
@@ -164,6 +165,12 @@ class LabMetadataManager(PortalBaseManager):
             qs = remove_not_sequenced(qs)
 
         return qs
+
+    def get_by_aggregate_count(self, field):
+        return self.values(field).annotate(count=Count(field)).order_by(field)
+
+    def get_by_cube(self, field_left, field_right, field_sort):
+        return self.values(field_left, field_right).annotate(count=Count(1)).order_by(field_sort)
 
 
 class LabMetadata(PortalBaseModel):

--- a/data_portal/models/limsrow.py
+++ b/data_portal/models/limsrow.py
@@ -3,6 +3,7 @@ from typing import Union
 
 from django.db import models
 from django.db.models import QuerySet
+from django.db.models.aggregates import Count
 
 from data_portal.models.base import PortalBaseManager, PortalBaseModel
 from data_portal.models.s3object import S3Object
@@ -26,6 +27,12 @@ class LIMSRowManager(PortalBaseManager):
             kwargs.pop('run')
 
         return self.get_model_fields_query(qs, **kwargs)
+
+    def get_by_aggregate_count(self, field):
+        return self.values(field).annotate(count=Count(field)).order_by(field)
+
+    def get_by_cube(self, field_left, field_right, field_sort):
+        return self.values(field_left, field_right).annotate(count=Count(1)).order_by(field_sort)
 
 
 class LIMSRow(PortalBaseModel):

--- a/data_portal/viewsets/limsrow.py
+++ b/data_portal/viewsets/limsrow.py
@@ -7,6 +7,8 @@ NOTE:
 import logging
 
 from rest_framework import filters
+from rest_framework.decorators import action
+from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from data_portal.models.limsrow import LIMSRow
@@ -14,6 +16,8 @@ from data_portal.pagination import StandardResultsSetPagination
 from data_portal.serializers import LIMSRowModelSerializer
 
 logger = logging.getLogger()
+
+allowed_fields = ['project_name', 'project_owner', 'workflow', 'source', 'assay', 'type', 'phenotype']
 
 
 class LIMSRowViewSet(ReadOnlyModelViewSet):
@@ -26,3 +30,38 @@ class LIMSRowViewSet(ReadOnlyModelViewSet):
 
     def get_queryset(self):
         return LIMSRow.objects.get_by_keyword(**self.request.query_params)
+
+    @action(detail=False, methods=['get'])
+    def by_aggregate_count(self, request):
+        fields = self.request.query_params.getlist('fields', None)
+
+        if fields is None or not fields:
+            return Response(data={})
+
+        if 'all' in fields:
+            fields.clear()
+            fields.extend(allowed_fields)
+
+        fields = list(set(fields) & set(allowed_fields))  # intersect
+
+        data = {}
+        for f in fields:
+            data.update({
+                str(f): LIMSRow.objects.get_by_aggregate_count(str(f))
+            })
+
+        return Response(data=data)
+
+    @action(detail=False, methods=['get'])
+    def by_cube(self, request):
+        fields = self.request.query_params.getlist('fields', None)
+
+        if fields is None or not fields or len(fields) < 2:
+            return Response(data={})
+
+        if not all(item in allowed_fields for item in fields):
+            return Response(data={})
+
+        data = LIMSRow.objects.get_by_cube(field_left=fields[0], field_right=fields[1], field_sort=fields[0])
+
+        return Response(data=data)


### PR DESCRIPTION
* This gives aggregation (group by, count) of defined LIMS/Meta columns
  ```
  /[lims|metadata]/by_aggregate_count?fields=all
  /[lims|metadata]/by_aggregate_count?fields=workflow&fields=project_owner
  ```
* Also. Added "Data Cube" aggregation (experimental) for defined LIMS/Meta columns
  ```
  /[lims|metadata]/by_cube?fields=type&fields=assay
  ```
  At the mo, supporting 2D to start with -- You can pass-in 2 fields for pivoting the combo.
  The first field takes as ordering field (sort field) in ascending.
  For example, we can build this view:
  ```
  WGS,AgSsCRE,2
  WGS,PCR-Free-Tagmentation,4
  WGS,TPlxHV,9
  WGS,TSODNA,1
  WGS,TsqNano,2527
  WTS,NebRNA,1049
  ...
  ```
