### PR TITLE
Run QC for WTS alongside WGS

### DIFF
--- a/data_portal/tests/factories.py
+++ b/data_portal/tests/factories.py
@@ -356,6 +356,28 @@ class WorkflowFactory(factory.django.DjangoModelFactory):
     )
 
 
+class DragenWgtsQcWorkflowFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Workflow
+
+    sequence_run = factory.SubFactory(SequenceRunFactory)
+    wfr_id = TestConstant.wfr_id.value
+    wfv_id = TestConstant.wfv_id.value
+    wfl_id = TestConstant.wfl_id.value
+    version = TestConstant.version.value
+    type_name = WorkflowType.DRAGEN_WGTS_QC.value
+    input = json.dumps({
+        "mock": "must load template from ssm parameter store"
+    })
+    start = make_aware(datetime.now())
+    end_status = WorkflowStatus.RUNNING.value
+    notified = True
+
+    wfr_name = factory.LazyAttribute(
+        lambda w: f"umccr__{w.type_name}__{w.sequence_run.name}__{w.sequence_run.run_id}__{utc_now_ts}"
+    )
+
+
 class DragenWgsQcWorkflowFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Workflow
@@ -366,6 +388,28 @@ class DragenWgsQcWorkflowFactory(factory.django.DjangoModelFactory):
     wfl_id = TestConstant.wfl_id.value
     version = TestConstant.version.value
     type_name = WorkflowType.DRAGEN_WGS_QC.value
+    input = json.dumps({
+        "mock": "must load template from ssm parameter store"
+    })
+    start = make_aware(datetime.now())
+    end_status = WorkflowStatus.RUNNING.value
+    notified = True
+
+    wfr_name = factory.LazyAttribute(
+        lambda w: f"umccr__{w.type_name}__{w.sequence_run.name}__{w.sequence_run.run_id}__{utc_now_ts}"
+    )
+
+
+class DragenWtsQcWorkflowFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Workflow
+
+    sequence_run = factory.SubFactory(SequenceRunFactory)
+    wfr_id = TestConstant.wfr_id.value
+    wfv_id = TestConstant.wfv_id.value
+    wfl_id = TestConstant.wfl_id.value
+    version = TestConstant.version.value
+    type_name = WorkflowType.DRAGEN_WTS_QC.value
     input = json.dumps({
         "mock": "must load template from ssm parameter store"
     })

--- a/data_portal/viewsets/tests/test_libraryrun.py
+++ b/data_portal/viewsets/tests/test_libraryrun.py
@@ -2,14 +2,14 @@ from django.test import TestCase
 
 from data_portal.models.libraryrun import LibraryRun
 from data_portal.models.workflow import Workflow
-from data_portal.tests.factories import DragenWgsQcWorkflowFactory, TestConstant
+from data_portal.tests.factories import DragenWgtsQcWorkflowFactory, TestConstant
 from data_portal.viewsets.tests import _logger
 
 
 class LibraryRunViewSetTestCase(TestCase):
 
     def setUp(self):
-        self.mock_qc_wfl: Workflow = DragenWgsQcWorkflowFactory()
+        self.mock_qc_wfl: Workflow = DragenWgtsQcWorkflowFactory()
 
         self.mock_lib_run = LibraryRun.objects.create(
             library_id=TestConstant.library_id_tumor.value,

--- a/data_processors/pipeline/domain/tests/test_pairing.py
+++ b/data_processors/pipeline/domain/tests/test_pairing.py
@@ -1,7 +1,7 @@
 from mockito import when
 
 from data_portal.models.workflow import Workflow
-from data_portal.tests.factories import DragenWgsQcWorkflowFactory, LabMetadataFactory
+from data_portal.tests.factories import DragenWgtsQcWorkflowFactory, LabMetadataFactory
 from data_processors.pipeline.domain.pairing import Pairing, CollectionBasedFluentImpl, TNPairing
 from data_processors.pipeline.services import sequencerun_srv, workflow_srv, metadata_srv
 from data_processors.pipeline.tests.case import PipelineUnitTestCase, PipelineIntegrationTestCase, logger
@@ -44,7 +44,7 @@ class PairingUnitTests(PipelineUnitTestCase):
         """
         python manage.py test data_processors.pipeline.domain.tests.test_pairing.PairingUnitTests.test_by_sequence_runs
         """
-        mock_workflow: Workflow = DragenWgsQcWorkflowFactory()
+        mock_workflow: Workflow = DragenWgtsQcWorkflowFactory()
         when(workflow_srv).get_succeeded_by_sequence_run(...).thenReturn([mock_workflow])
 
         mock_seq_run = mock_workflow.sequence_run

--- a/data_processors/pipeline/domain/workflow.py
+++ b/data_processors/pipeline/domain/workflow.py
@@ -42,8 +42,12 @@ class WorkflowType(Enum):
     def from_value(cls, value):
         if value == cls.BCL_CONVERT.value:
             return cls.BCL_CONVERT
+        elif value == cls.DRAGEN_WGTS_QC.value:
+            return cls.DRAGEN_WGTS_QC
         elif value == cls.DRAGEN_WGS_QC.value:
             return cls.DRAGEN_WGS_QC
+        elif value == cls.DRAGEN_WTS_QC.value:
+            return cls.DRAGEN_WTS_QC
         elif value == cls.TUMOR_NORMAL.value:
             return cls.TUMOR_NORMAL
         elif value == cls.DRAGEN_TSO_CTDNA.value:

--- a/data_processors/pipeline/domain/workflow.py
+++ b/data_processors/pipeline/domain/workflow.py
@@ -29,7 +29,9 @@ class SampleSheetCSV(Enum):
 
 class WorkflowType(Enum):
     BCL_CONVERT = "bcl_convert"
+    DRAGEN_WGTS_QC = "wgts_alignment_qc"  # Placeholder workflow type
     DRAGEN_WGS_QC = "wgs_alignment_qc"
+    DRAGEN_WTS_QC = "wts_alignment_qc"
     TUMOR_NORMAL = "wgs_tumor_normal"
     DRAGEN_TSO_CTDNA = "tso_ctdna_tumor_only"
     DRAGEN_WTS = "wts_tumor_only"
@@ -368,6 +370,13 @@ class LabMetadataRule:
         from data_portal.models.labmetadata import LabMetadataType
         if self.this_metadata.type.lower() != LabMetadataType.WGS.value.lower():
             raise LabMetadataRuleError(f"'WGS' != '{self.this_metadata.type}'.")
+        return self
+
+    def must_be_wgts(self):
+        from data_portal.models.labmetadata import LabMetadataType
+        wgts_values = [ LabMetadataType.WGS.value.lower(), LabMetadataType.WTS.value.lower() ]
+        if self.this_metadata.type.lower() not in wgts_values:
+            raise LabMetadataRuleError(f"'WGS' or 'WTS' != '{self.this_metadata.type}'.")
         return self
 
     def must_be_wts(self):

--- a/data_processors/pipeline/domain/workflow.py
+++ b/data_processors/pipeline/domain/workflow.py
@@ -191,6 +191,8 @@ class SecondaryAnalysisHelper(WorkflowHelper):
     def __init__(self, type_: WorkflowType):
         allowed_workflow_types = [
             WorkflowType.DRAGEN_WGS_QC,
+            WorkflowType.DRAGEN_WGTS_QC,
+            WorkflowType.DRAGEN_WTS_QC,
             WorkflowType.DRAGEN_TSO_CTDNA,
             WorkflowType.DRAGEN_WTS,
             WorkflowType.TUMOR_NORMAL,

--- a/data_processors/pipeline/lambdas/dragen_wgs_qc.py
+++ b/data_processors/pipeline/lambdas/dragen_wgs_qc.py
@@ -1,5 +1,3 @@
-from data_portal.models.labmetadata import LabMetadataType
-
 try:
     import unzip_requirements
 except ImportError:
@@ -17,6 +15,7 @@ import logging
 
 from data_portal.models.workflow import Workflow
 from data_processors.pipeline.services import sequencerun_srv, batch_srv, workflow_srv, metadata_srv, libraryrun_srv
+from data_portal.models.labmetadata import LabMetadataType
 from data_processors.pipeline.domain.workflow import WorkflowType, SecondaryAnalysisHelper
 from data_processors.pipeline.lambdas import wes_handler
 from libumccr import libjson, libdt

--- a/data_processors/pipeline/lambdas/dragen_wgs_qc.py
+++ b/data_processors/pipeline/lambdas/dragen_wgs_qc.py
@@ -107,6 +107,11 @@ def handler(event, context) -> dict:
     # Get metadata by library id
     library_lab_metadata = metadata_srv.get_metadata_by_library_id(library_id)
 
+    # Check type is not None
+    if library_lab_metadata is None:
+        logger.error(f"Expected to retrieve metadata for library '{library_id}' but no metadata was returned")
+        raise ValueError
+
     # We set the RNA flag and set the workflow type based on the library lab metadata
     if library_lab_metadata.type == LabMetadataType.WTS:
         workflow_type = WorkflowType.DRAGEN_WTS_QC

--- a/data_processors/pipeline/lambdas/dragen_wgs_qc.py
+++ b/data_processors/pipeline/lambdas/dragen_wgs_qc.py
@@ -1,3 +1,5 @@
+from data_portal.models.labmetadata import LabMetadataType
+
 try:
     import unzip_requirements
 except ImportError:
@@ -87,7 +89,7 @@ def handler(event, context) -> dict:
     :return: workflow db record id, wfr_id, sample_name in JSON string
     """
 
-    logger.info(f"Start processing {WorkflowType.DRAGEN_WGS_QC.value} event")
+    logger.info(f"Start processing {WorkflowType.DRAGEN_WGTS_QC.value} event")
     logger.info(libjson.dumps(event))
 
     # Extract name of sample and the fastq list rows
@@ -103,13 +105,28 @@ def handler(event, context) -> dict:
 
     sample_name = fastq_list_rows[0]['rgsm']
 
-    # Set workflow helper
-    wfl_helper = SecondaryAnalysisHelper(WorkflowType.DRAGEN_WGS_QC)
+    # Get metadata by library id
+    library_lab_metadata = metadata_srv.get_metadata_by_library_id(library_id)
 
+    # We set the RNA flag and set the workflow type based on the library lab metadata
+    if library_lab_metadata.type == LabMetadataType.WTS:
+        workflow_type = WorkflowType.DRAGEN_WTS_QC
+        enable_rna = True
+    elif library_lab_metadata.type == LabMetadataType.WGS:
+        workflow_type = WorkflowType.DRAGEN_WGS_QC
+        enable_rna = False
+    else:
+        logger.error(f"Expected metadata type for library id '{library_id}' to be one of WGS or WTS")
+        raise ValueError
+
+    wfl_helper = SecondaryAnalysisHelper(workflow_type)
+
+    # Set workflow helper
     workflow_input: dict = wfl_helper.get_workflow_input()
     workflow_input["output_file_prefix"] = f"{sample_name}"
     workflow_input["output_directory"] = f"{library_id}__{lane}_dragen"
     workflow_input["fastq_list_rows"] = fastq_list_rows
+    workflow_input["enable_rna"] = enable_rna
 
     # read workflow id and version from parameter store
     workflow_id = wfl_helper.get_workflow_id()
@@ -125,13 +142,16 @@ def handler(event, context) -> dict:
 
     workflow_engine_parameters = wfl_helper.get_engine_parameters(target_id=subject_id, secondary_target_id=None)
 
-    wfl_run = wes_handler.launch({
-        'workflow_id': workflow_id,
-        'workflow_version': workflow_version,
-        'workflow_run_name': workflow_run_name,
-        'workflow_input': workflow_input,
-        'workflow_engine_parameters': workflow_engine_parameters
-    }, context)
+    wfl_run = wes_handler.launch(
+        {
+            'workflow_id': workflow_id,
+            'workflow_version': workflow_version,
+            'workflow_run_name': workflow_run_name,
+            'workflow_input': workflow_input,
+            'workflow_engine_parameters': workflow_engine_parameters
+        },
+        context
+    )
 
     workflow: Workflow = workflow_srv.create_or_update_workflow(
         {

--- a/data_processors/pipeline/lambdas/dragen_wts.py
+++ b/data_processors/pipeline/lambdas/dragen_wts.py
@@ -83,9 +83,6 @@ def handler(event, context) -> dict:
             }
         }],
         "arriba_large_mem": true,
-        "seq_run_id": "sequence run id",
-        "seq_name": "sequence run name",
-        "batch_run_id": "batch run id",
     }
 
     :param event:
@@ -149,7 +146,7 @@ def handler(event, context) -> dict:
     )
 
     # establish link between Workflow and LibraryRun
-    _ = libraryrun_srv.link_library_runs_with_workflow(library_id, workflow)
+    _ = libraryrun_srv.link_library_runs_with_x_seq_workflow([library_id], workflow)
 
     # notification shall trigger upon wes.run event created action in workflow_update lambda
 

--- a/data_processors/pipeline/lambdas/orchestrator.py
+++ b/data_processors/pipeline/lambdas/orchestrator.py
@@ -187,7 +187,7 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
             logger.info("Updating Google LIMS")
             google_lims_update_step.perform(this_workflow)
 
-        if "DRAGEN_WGTS_QC_STEP" in skiplist:
+        if any([step in skiplist for step in ["DRAGEN_WGTS_QC_STEP", "DRAGEN_WGS_QC_STEP", "DRAGEN_WTS_QC_STEP"]]):
             logger.info("Skip performing DRAGEN_WGTS_QC_STEP")
         else:
             logger.info("Performing DRAGEN_WGTS_QC_STEP")

--- a/data_processors/pipeline/lambdas/orchestrator.py
+++ b/data_processors/pipeline/lambdas/orchestrator.py
@@ -187,10 +187,10 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
             logger.info("Updating Google LIMS")
             google_lims_update_step.perform(this_workflow)
 
-        if "DRAGEN_WGS_QC_STEP" in skiplist:
-            logger.info("Skip performing DRAGEN_WGS_QC_STEP")
+        if "DRAGEN_WGTS_QC_STEP" in skiplist:
+            logger.info("Skip performing DRAGEN_WGTS_QC_STEP")
         else:
-            logger.info("Performing DRAGEN_WGS_QC_STEP")
+            logger.info("Performing DRAGEN_WGTS_QC_STEP")
             results.append(dragen_wgs_qc_step.perform(this_workflow))
 
         if "DRAGEN_TSO_CTDNA_STEP" in skiplist:
@@ -198,12 +198,6 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
         else:
             logger.info("Performing DRAGEN_TSO_CTDNA_STEP")
             results.append(dragen_tso_ctdna_step.perform(this_workflow))
-
-        if "DRAGEN_WTS_STEP" in skiplist:
-            logger.info("Skip performing DRAGEN_WTS_STEP")
-        else:
-            logger.info("Performing DRAGEN_WTS_STEP")
-            results.append(dragen_wts_step.perform(this_workflow))
 
         return results
 
@@ -223,9 +217,11 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
 
         return results
 
-    elif this_workflow.type_name.lower() == WorkflowType.DRAGEN_WGS_QC.value.lower() and \
-            this_workflow.end_status.lower() == WorkflowStatus.SUCCEEDED.value.lower():
-        logger.info(f"Received DRAGEN_WGS_QC workflow notification")
+    elif (
+            this_workflow.type_name.lower() == WorkflowType.DRAGEN_WGS_QC.value.lower() or
+            this_workflow.type_name.lower() == WorkflowType.DRAGEN_WTS_QC.value.lower()
+    ) and this_workflow.end_status.lower() == WorkflowStatus.SUCCEEDED.value.lower():
+        logger.info(f"Received DRAGEN_WGTS_QC workflow notification")
 
         WorkflowRule(this_workflow).must_associate_sequence_run().must_have_output()
 
@@ -242,6 +238,12 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
         else:
             logger.info("Performing TUMOR_NORMAL_STEP")
             results.append(tumor_normal_step.perform(this_workflow))
+
+        if "DRAGEN_WTS_STEP" in skiplist:
+            logger.info("Skip performing DRAGEN_WTS_STEP")
+        else:
+            logger.info("Performing DRAGEN_WTS_STEP")
+            results.append(dragen_wts_step.perform(this_workflow))
 
         return results
 

--- a/data_processors/pipeline/lambdas/orchestrator.py
+++ b/data_processors/pipeline/lambdas/orchestrator.py
@@ -236,6 +236,8 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
         else:
             logger.info("Performing TUMOR_NORMAL_STEP")
             results.append(tumor_normal_step.perform(this_workflow))
+
+        return results
     elif this_workflow.type_name.lower() == WorkflowType.DRAGEN_WTS_QC.value.lower() and \
              this_workflow.end_status.lower() == WorkflowStatus.SUCCEEDED.value.lower():
         logger.info(f"Received DRAGEN_WTS_QC workflow notification")

--- a/data_processors/pipeline/lambdas/orchestrator.py
+++ b/data_processors/pipeline/lambdas/orchestrator.py
@@ -53,7 +53,7 @@ def handler(event, context):
                 "UPDATE_STEP",
                 "FASTQ_UPDATE_STEP",
                 "GOOGLE_LIMS_UPDATE_STEP",
-                "DRAGEN_WGS_QC_STEP",
+                "DRAGEN_WGTS_QC_STEP",
                 "DRAGEN_TSO_CTDNA_STEP",
                 "DRAGEN_WTS_STEP",
                 "TUMOR_NORMAL_STEP",
@@ -65,7 +65,7 @@ def handler(event, context):
                 '220524_A01010_0998_ABCF2HDSYX': [
                     "FASTQ_UPDATE_STEP",
                     "GOOGLE_LIMS_UPDATE_STEP",
-                    "DRAGEN_WGS_QC_STEP",
+                    "DRAGEN_WGTS_QC_STEP",
                     "DRAGEN_TSO_CTDNA_STEP",
                     "DRAGEN_WTS_STEP",
                 ],
@@ -73,7 +73,7 @@ def handler(event, context):
                     "UPDATE_STEP",
                     "FASTQ_UPDATE_STEP",
                     "GOOGLE_LIMS_UPDATE_STEP",
-                    "DRAGEN_WGS_QC_STEP",
+                    "DRAGEN_WGTS_QC_STEP",
                     "DRAGEN_TSO_CTDNA_STEP",
                     "DRAGEN_WTS_STEP",
                 ]
@@ -217,11 +217,9 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
 
         return results
 
-    elif (
-            this_workflow.type_name.lower() == WorkflowType.DRAGEN_WGS_QC.value.lower() or
-            this_workflow.type_name.lower() == WorkflowType.DRAGEN_WTS_QC.value.lower()
-    ) and this_workflow.end_status.lower() == WorkflowStatus.SUCCEEDED.value.lower():
-        logger.info(f"Received DRAGEN_WGTS_QC workflow notification")
+    elif this_workflow.type_name.lower() == WorkflowType.DRAGEN_WGS_QC.value.lower() and \
+            this_workflow.end_status.lower() == WorkflowStatus.SUCCEEDED.value.lower():
+        logger.info(f"Received DRAGEN_WGS_QC workflow notification")
 
         WorkflowRule(this_workflow).must_associate_sequence_run().must_have_output()
 
@@ -238,6 +236,13 @@ def next_step(this_workflow: Workflow, skip: dict, context=None):
         else:
             logger.info("Performing TUMOR_NORMAL_STEP")
             results.append(tumor_normal_step.perform(this_workflow))
+    elif this_workflow.type_name.lower() == WorkflowType.DRAGEN_WTS_QC.value.lower() and \
+             this_workflow.end_status.lower() == WorkflowStatus.SUCCEEDED.value.lower():
+        logger.info(f"Received DRAGEN_WTS_QC workflow notification")
+
+        WorkflowRule(this_workflow).must_associate_sequence_run().must_have_output()
+
+        results = list()
 
         if "DRAGEN_WTS_STEP" in skiplist:
             logger.info("Skip performing DRAGEN_WTS_STEP")

--- a/data_processors/pipeline/lambdas/tests/test_dragen_wgs_qc.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_wgs_qc.py
@@ -9,7 +9,7 @@ from mockito import when
 from data_portal.models.libraryrun import LibraryRun
 from data_portal.models.sequencerun import SequenceRun
 from data_portal.models.workflow import Workflow
-from data_portal.tests.factories import SequenceRunFactory, TestConstant, LibraryRunFactory
+from data_portal.tests.factories import SequenceRunFactory, TestConstant, LibraryRunFactory, LabMetadataFactory
 from data_processors.pipeline.domain.workflow import SecondaryAnalysisHelper
 from data_processors.pipeline.domain.workflow import WorkflowStatus
 from data_processors.pipeline.lambdas import dragen_wgs_qc
@@ -23,8 +23,10 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
         """
         python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_wgs_qc.DragenWgsQcUnitTests.test_handler
         """
+        mock_normal_library = LabMetadataFactory()
         mock_library_run: LibraryRun = LibraryRunFactory()
         mock_sqr: SequenceRun = SequenceRunFactory()
+
         when(metadata_srv).get_subject_id_from_library_id(...).thenReturn("SBJ00001")
 
         workflow: dict = dragen_wgs_qc.handler({
@@ -70,6 +72,7 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
         """
         python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_wgs_qc.DragenWgsQcUnitTests.test_handler_alt
         """
+        mock_normal_library = LabMetadataFactory()
         mock_sqr: SequenceRun = SequenceRunFactory()
         when(metadata_srv).get_subject_id_from_library_id(...).thenReturn("SBJ00001")
 
@@ -83,7 +86,7 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
         when(libwes.WorkflowVersionsApi).launch_workflow_version(...).thenReturn(mock_wfr)
 
         workflow: dict = dragen_wgs_qc.handler({
-            "library_id": "SAMPLE_NAME",
+            "library_id": TestConstant.library_id_normal.value,
             "lane": 1,
             "fastq_list_rows": [
                 {
@@ -116,12 +119,12 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
         """
         python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_wgs_qc.DragenWgsQcUnitTests.test_sqs_handler
         """
-
+        mock_normal_library = LabMetadataFactory()
         mock_sqr: SequenceRun = SequenceRunFactory()
         when(metadata_srv).get_subject_id_from_library_id(...).thenReturn("SBJ0001")
 
         mock_job = {
-            "library_id": "SAMPLE_NAME",
+            "library_id": TestConstant.library_id_normal.value,
             "lane": 1,
             "fastq_list_rows": [
                 {
@@ -169,6 +172,7 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
         python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_wgs_qc.DragenWgsQcUnitTests.test_portal_run_id
         """
         mock_portal_run_id = "20211101a1b2c3d4"
+        mock_normal_library = LabMetadataFactory()
         LibraryRunFactory()
         mock_sqr: SequenceRun = SequenceRunFactory()
         when(metadata_srv).get_subject_id_from_library_id(...).thenReturn("SBJ00001")

--- a/data_processors/pipeline/lambdas/tests/test_dragen_wts.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_wts.py
@@ -9,7 +9,7 @@ from mockito import when
 from data_portal.models.libraryrun import LibraryRun
 from data_portal.models.sequencerun import SequenceRun
 from data_portal.models.workflow import Workflow
-from data_portal.tests.factories import SequenceRunFactory, TestConstant, LibraryRunFactory
+from data_portal.tests.factories import SequenceRunFactory, TestConstant, WtsTumorLibraryRunFactory, LibraryRunFactory
 from data_processors.pipeline.domain.workflow import WorkflowStatus, WorkflowType, SecondaryAnalysisHelper
 from data_processors.pipeline.lambdas import dragen_wts
 from data_processors.pipeline.lambdas.dragen_wts import override_arriba_fusion_step_resources, ARRIBA_FUSION_STEP_KEY_ID
@@ -24,10 +24,12 @@ class DragenWtsUnitTests(PipelineUnitTestCase):
         python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_wts.DragenWtsUnitTests.test_handler
         """
         mock_library_run: LibraryRun = LibraryRunFactory()
+        mock_tumor_library_run: LibraryRun = WtsTumorLibraryRunFactory()
         mock_sqr: SequenceRun = SequenceRunFactory()
         when(metadata_srv).get_subject_id_from_library_id(...).thenReturn("SBJ00001")
 
         workflow: dict = dragen_wts.handler({
+            "subject_id": TestConstant.subject_id.value,
             "library_id": TestConstant.library_id_normal.value,
             "fastq_list_rows": [
                 {
@@ -44,9 +46,7 @@ class DragenWtsUnitTests(PipelineUnitTestCase):
                       "location": "gds://path/to/read_2.fastq.gz"
                     }
                 }
-            ],
-            "seq_run_id": mock_sqr.run_id,
-            "seq_name": mock_sqr.name,
+            ]
         }, None)
 
         logger.info("-" * 32)
@@ -83,7 +83,8 @@ class DragenWtsUnitTests(PipelineUnitTestCase):
         when(libwes.WorkflowVersionsApi).launch_workflow_version(...).thenReturn(mock_wfr)
 
         workflow: dict = dragen_wts.handler({
-            "library_id": "SAMPLE_NAME",
+            "subject_id": TestConstant.subject_id.value,
+            "library_id": TestConstant.library_id_normal.value,
             "fastq_list_rows": [
                 {
                     "rgid": "index1.index2.lane",
@@ -121,6 +122,7 @@ class DragenWtsUnitTests(PipelineUnitTestCase):
         when(metadata_srv).get_subject_id_from_library_id(...).thenReturn("SBJ00001")
 
         mock_job = {
+            "subject_id": "SUBJECT_ID",
             "library_id": "SAMPLE_NAME",
             "fastq_list_rows": [
                 {

--- a/data_processors/pipeline/lambdas/tests/test_orchestrator.py
+++ b/data_processors/pipeline/lambdas/tests/test_orchestrator.py
@@ -158,7 +158,7 @@ class OrchestratorUnitTests(PipelineUnitTestCase):
 
         self.assertTrue('DRAGEN_WGS_QC_STEP' in results)
         self.assertTrue('DRAGEN_TSO_CTDNA_STEP' in results)
-        self.assertTrue('DRAGEN_WTS_STEP' in results)
+        self.assertFalse('DRAGEN_WTS_STEP' in results)
 
     def test_skip_list_run_skip(self):
         """
@@ -176,16 +176,16 @@ class OrchestratorUnitTests(PipelineUnitTestCase):
 
         when(fastq_update_step).perform(...).thenReturn("FASTQ_UPDATE_STEP")
         when(google_lims_update_step).perform(...).thenReturn('GOOGLE_LIMS_UPDATE_STEP')
-        when(dragen_wgs_qc_step).perform(...).thenReturn('DRAGEN_WGS_QC_STEP')
+        when(dragen_wgs_qc_step).perform(...).thenReturn('DRAGEN_WGTS_QC_STEP')
         when(dragen_tso_ctdna_step).perform(...).thenReturn('DRAGEN_TSO_CTDNA_STEP')
-        when(dragen_wts_step).perform(...).thenReturn('DRAGEN_WTS_STEP')
+        when(dragen_wts_step).perform(...).thenReturn('DRAGEN_WTS_QC_STEP')
 
         run_id = TestConstant.instrument_run_id.value
         skiplist = {
             'global': [],
             'by_run': {
                 run_id: [
-                    "DRAGEN_WGS_QC_STEP"
+                    "DRAGEN_WGTS_QC_STEP"
                 ]
             }
         }
@@ -193,9 +193,8 @@ class OrchestratorUnitTests(PipelineUnitTestCase):
         results = orchestrator.next_step(mock_workflow, skiplist, None)
         logger.info(results)
 
-        self.assertFalse('DRAGEN_WGS_QC_STEP' in results)
+        self.assertFalse('DRAGEN_WGTS_QC_STEP' in results)
         self.assertTrue('DRAGEN_TSO_CTDNA_STEP' in results)
-        self.assertTrue('DRAGEN_WTS_STEP' in results)
 
         skiplist = {
             'global': ["DRAGEN_WGS_QC_STEP"],
@@ -250,14 +249,13 @@ class OrchestratorUnitTests(PipelineUnitTestCase):
         # by_run skip list should not apply, since run id mismatch, so all workflows should be listed
         self.assertTrue('DRAGEN_WGS_QC_STEP' in results)
         self.assertTrue('DRAGEN_TSO_CTDNA_STEP' in results)
-        self.assertTrue('DRAGEN_WTS_STEP' in results)
+        self.assertFalse('DRAGEN_WTS_STEP' in results)
 
         skiplist = {
             'global': ["DRAGEN_WGS_QC_STEP"],
             'by_run': {
                 run_id: [
                     "DRAGEN_TSO_CTDNA_STEP",
-                    "DRAGEN_WTS_STEP"
                 ]
             }
         }
@@ -268,7 +266,6 @@ class OrchestratorUnitTests(PipelineUnitTestCase):
         # only global skip list should apply, due to run ID mismatch
         self.assertFalse('DRAGEN_WGS_QC_STEP' in results)
         self.assertTrue('DRAGEN_TSO_CTDNA_STEP' in results)
-        self.assertTrue('DRAGEN_WTS_STEP' in results)
 
 
 class OrchestratorIntegrationTests(PipelineIntegrationTestCase):

--- a/data_processors/pipeline/lambdas/tests/test_sqs_iap_event.py
+++ b/data_processors/pipeline/lambdas/tests/test_sqs_iap_event.py
@@ -387,7 +387,7 @@ class SQSIAPEventUnitTests(PipelineUnitTestCase):
 
         self.assertEqual(1, Workflow.objects.count())
 
-        wgs_qc_batch_runs = [br for br in BatchRun.objects.all() if br.step == WorkflowType.DRAGEN_WGS_QC.value]
+        wgs_qc_batch_runs = [br for br in BatchRun.objects.all() if br.step == WorkflowType.DRAGEN_WGTS_QC.value]
 
         self.assertTrue(BatchRun.objects.count() > 1)
         self.assertTrue(wgs_qc_batch_runs[0].running)

--- a/data_processors/pipeline/orchestration/__init__.py
+++ b/data_processors/pipeline/orchestration/__init__.py
@@ -25,8 +25,12 @@ from typing import List
 
 import pandas as pd
 
+from data_portal.models.fastqlistrow import FastqListRow
 from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType
 from data_processors.pipeline.tools import liborca
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def _reduce_and_transform_to_df(meta_list: List[LabMetadata]) -> pd.DataFrame:
@@ -72,3 +76,14 @@ def _mint_libraries(libraries):
     for lib in libraries:
         s.add(liborca.strip_topup_rerun_from_library_id(lib))
     return list(s)
+
+
+def _handle_rerun(fastq_list_rows: List[FastqListRow], library_id):
+    for fastq_list_row in fastq_list_rows:
+        full_sample_library_id = fastq_list_row.rgid.rsplit(".", 1)[-1]
+        if liborca.sample_library_id_has_rerun(full_sample_library_id):
+            logger.warning(f"We found a rerun for library id {library_id} in {full_sample_library_id}. "
+                           f"Please run this sample manually")
+            # Reset fastq list rows - we don't know what to do with reruns
+            return []
+    return fastq_list_rows

--- a/data_processors/pipeline/orchestration/__init__.py
+++ b/data_processors/pipeline/orchestration/__init__.py
@@ -28,6 +28,7 @@ import pandas as pd
 from data_portal.models.fastqlistrow import FastqListRow
 from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType
 from data_processors.pipeline.tools import liborca
+import logging
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/data_processors/pipeline/orchestration/dragen_wgs_qc_step.py
+++ b/data_processors/pipeline/orchestration/dragen_wgs_qc_step.py
@@ -24,11 +24,11 @@ logger.setLevel(logging.INFO)
 
 
 def perform(this_workflow: Workflow):
-    logger.info(f"Preparing {WorkflowType.DRAGEN_WGS_QC.value} workflows")
+    logger.info(f"Preparing {WorkflowType.DRAGEN_WGTS_QC.value} workflows")
 
     batcher = Batcher(
         workflow=this_workflow,
-        run_step=WorkflowType.DRAGEN_WGS_QC.value,
+        run_step=WorkflowType.DRAGEN_WGTS_QC.value,
         batch_srv=batch_srv,
         fastq_srv=fastq_srv,
         logger=logger,
@@ -41,6 +41,7 @@ def perform(this_workflow: Workflow):
     job_list = prepare_dragen_wgs_qc_jobs(batcher)
     if job_list:
         libsqs.dispatch_jobs(
+            # Used for both WGS and WTS
             queue_arn=libssm.get_ssm_param(SQS_DRAGEN_WGS_QC_QUEUE_ARN),
             job_list=job_list
         )
@@ -78,7 +79,7 @@ def prepare_dragen_wgs_qc_jobs(batcher: Batcher) -> List[dict]:
                 .must_set_workflow() \
                 .must_not_manual() \
                 .must_not_bcl() \
-                .must_be_wgs()
+                .must_be_wgts()
 
             BatchRule(
                 batcher=batcher,
@@ -87,7 +88,7 @@ def prepare_dragen_wgs_qc_jobs(batcher: Batcher) -> List[dict]:
             ).must_not_have_succeeded_runs()
 
         except LabMetadataRuleError as me:
-            logger.warning(f"SKIP {WorkflowType.DRAGEN_WGS_QC.value} workflow for '{rgsm}_{rglb}' in lane {lane}. {me}")
+            logger.warning(f"SKIP {WorkflowType.DRAGEN_WGTS_QC.value} workflow for '{rgsm}_{rglb}' in lane {lane}. {me}")
             continue
 
         except BatchRuleError as be:

--- a/data_processors/pipeline/orchestration/dragen_wts_step.py
+++ b/data_processors/pipeline/orchestration/dragen_wts_step.py
@@ -15,9 +15,8 @@ from data_portal.models.labmetadata import LabMetadata
 from data_portal.models.workflow import Workflow
 from data_processors.pipeline.domain.config import SQS_DRAGEN_WTS_QUEUE_ARN
 from data_processors.pipeline.domain.workflow import WorkflowType
-from data_processors.pipeline.orchestration import _reduce_and_transform_to_df, _extract_unique_subjects
+from data_processors.pipeline.orchestration import _reduce_and_transform_to_df, _extract_unique_subjects, _handle_rerun
 from data_processors.pipeline.services import workflow_srv, metadata_srv, fastq_srv
-from data_processors.pipeline.tools.liborca import _handle_rerun
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -30,7 +29,7 @@ def perform(this_workflow: Workflow):
 
     # Check if all other DRAGEN_WTS_QC workflows for this run have finished
     # If yes we continue to the DRAGEN WTS Workflow
-    # If not we wait (until all DRAGEN_WTS_QC worklfows for this run have finished
+    # If not we wait (until all DRAGEN_WTS_QC workflows for this run have finished
     running: List[Workflow] = workflow_srv.get_running_by_sequence_run(
         sequence_run=this_sqr,
         workflow_type=WorkflowType.DRAGEN_WTS_QC
@@ -58,7 +57,7 @@ def perform(this_workflow: Workflow):
         else:
             logger.warning(f"Calling to prepare_tumor_normal_jobs() return empty list, no job to dispatch...")
     else:
-        logger.warning(f"DRAGEN_WGS_QC workflow finished, but {len(running)} still running. Wait for them to finish...")
+        logger.warning(f"DRAGEN_WTS_QC workflow finished, but {len(running)} still running. Wait for them to finish...")
 
     return {
         "subjects": subjects,

--- a/data_processors/pipeline/orchestration/dragen_wts_step.py
+++ b/data_processors/pipeline/orchestration/dragen_wts_step.py
@@ -45,6 +45,7 @@ def perform(this_workflow: Workflow):
         logger.info("All QC workflows finished, proceeding to dragen wts preparation")
 
         meta_list, run_libraries = metadata_srv.get_wts_metadata_by_wts_qc_runs(succeeded)
+
         if not meta_list:
             logger.warning(f"No dragen wts metadata found for given run libraries: {run_libraries}")
 

--- a/data_processors/pipeline/orchestration/dragen_wts_step.py
+++ b/data_processors/pipeline/orchestration/dragen_wts_step.py
@@ -5,19 +5,19 @@ See domain package __init__.py doc string.
 See orchestration package __init__.py doc string.
 """
 import logging
-from typing import List
+from typing import List, Dict
 
 import pandas as pd
-from libumccr import libjson
 from libumccr.aws import libssm, libsqs
 
+from data_portal.models.fastqlistrow import FastqListRow
 from data_portal.models.labmetadata import LabMetadata
 from data_portal.models.workflow import Workflow
-from data_processors.pipeline.domain.batch import Batcher, BatchRule, BatchRuleError
 from data_processors.pipeline.domain.config import SQS_DRAGEN_WTS_QUEUE_ARN
-from data_processors.pipeline.domain.workflow import WorkflowType, LabMetadataRule, LabMetadataRuleError
-from data_processors.pipeline.services import batch_srv, fastq_srv, metadata_srv, libraryrun_srv
-from data_processors.pipeline.tools import liborca
+from data_processors.pipeline.domain.workflow import WorkflowType
+from data_processors.pipeline.orchestration import _reduce_and_transform_to_df, _extract_unique_subjects
+from data_processors.pipeline.services import workflow_srv, metadata_srv, fastq_srv
+from data_processors.pipeline.tools.liborca import _handle_rerun
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -26,90 +26,99 @@ logger.setLevel(logging.INFO)
 def perform(this_workflow: Workflow):
     logger.info(f"Preparing {WorkflowType.DRAGEN_WTS.value} workflows")
 
-    batcher = Batcher(
-        workflow=this_workflow,
-        run_step=WorkflowType.DRAGEN_WTS.value,
-        batch_srv=batch_srv,
-        fastq_srv=fastq_srv,
-        logger=logger,
+    this_sqr = this_workflow.sequence_run
+
+    # Check if all other DRAGEN_WTS_QC workflows for this run have finished
+    # If yes we continue to the DRAGEN WTS Workflow
+    # If not we wait (until all DRAGEN_WTS_QC worklfows for this run have finished
+    running: List[Workflow] = workflow_srv.get_running_by_sequence_run(
+        sequence_run=this_sqr,
+        workflow_type=WorkflowType.DRAGEN_WTS_QC
+    )
+    succeeded: List[Workflow] = workflow_srv.get_succeeded_by_sequence_run(
+        sequence_run=this_sqr,
+        workflow_type=WorkflowType.DRAGEN_WTS_QC
     )
 
-    if batcher.batch_run is None:
-        return batcher.get_skip_message()
+    subjects = list()
+    submitting_subjects = list()
+    if len(running) == 0:
+        logger.info("All QC workflows finished, proceeding to dragen wts preparation")
 
-    # prepare job list and dispatch to job queue
-    job_list = prepare_dragen_wts_jobs(batcher)
-    if job_list:
-        libsqs.dispatch_jobs(
-            queue_arn=libssm.get_ssm_param(SQS_DRAGEN_WTS_QUEUE_ARN),
-            job_list=job_list
-        )
+        meta_list, run_libraries = metadata_srv.get_wts_metadata_by_wts_qc_runs(succeeded)
+        if not meta_list:
+            logger.warning(f"No dragen wts metadata found for given run libraries: {run_libraries}")
+
+        job_list, subjects, submitting_subjects = prepare_dragen_wts_jobs(meta_list)
+
+        if job_list:
+            logger.info(f"Submitting {len(job_list)} WTS jobs for {submitting_subjects}.")
+            queue_arn = libssm.get_ssm_param(SQS_DRAGEN_WTS_QUEUE_ARN)
+            libsqs.dispatch_jobs(queue_arn=queue_arn, job_list=job_list)
+        else:
+            logger.warning(f"Calling to prepare_tumor_normal_jobs() return empty list, no job to dispatch...")
     else:
-        batcher.reset_batch_run()  # reset running if job_list is empty
+        logger.warning(f"DRAGEN_WGS_QC workflow finished, but {len(running)} still running. Wait for them to finish...")
 
-    return batcher.get_status()
+    return {
+        "subjects": subjects,
+        "submitting_subjects": submitting_subjects
+    }
 
 
-def prepare_dragen_wts_jobs(batcher: Batcher) -> List[dict]:
+def prepare_dragen_wts_jobs(meta_list: List[LabMetadata]) -> (List, List, List):
     """
-    NOTE: like DRAGEN_WGS_QC CWL workflow, DRAGEN_WTS also uses fastq_list_rows format
+    NOTE: like TN Workflow dragen wts now uses the metadata list format
     See ICA catalogue
-    https://github.com/umccr/cwl-ica/blob/main/.github/catalogue/docs/workflows/dragen-transcriptome-pipeline/3.8.4/dragen-transcriptome-pipeline__3.8.4.md
+    https://github.com/umccr/cwl-ica/blob/main/.github/catalogue/docs/workflows/dragen-transcriptome-pipeline/3.9.3/dragen-transcriptome-pipeline__3.9.3.md
 
     DRAGEN_WTS job preparation is at _pure_ Library level.
     Here "Pure" Library ID means we don't need to worry about _topup(N) or _rerun(N) suffixes.
 
-    :param batcher:
-    :return:
+    :param meta_list:
+    :return: job_list, subjects, submitting_subjects
     """
-    job_list = []
-    fastq_list_rows: List[dict] = libjson.loads(batcher.batch.context_data)
+    job_list = list()
+    submitting_subjects = list()
 
-    # iterate through each sample group by rglb
-    for rglb, rglb_df in pd.DataFrame(fastq_list_rows).groupby("rglb"):
-        # Check rgsm is identical
-        # .item() will raise error if there exists more than one sample name for a given library
-        rgsm = rglb_df['rgsm'].unique().item()
+    # step 1 and 3
+    if not meta_list:
+        return [], [], []
 
-        # Get the metadata for the library
-        # NOTE: this will use the library base ID (i.e. without topup/rerun extension), as the metadata is the same
-        this_metadata: LabMetadata = metadata_srv.get_metadata_by_library_id(rglb)
+    meta_list_df = _reduce_and_transform_to_df(meta_list)
 
-        try:
-            LabMetadataRule(this_metadata) \
-                .must_set_workflow() \
-                .must_not_manual() \
-                .must_not_bcl() \
-                .must_not_qc() \
-                .must_be_wts() \
-                .must_be_tumor()
+    if meta_list_df.shape[0] == 0:
+        return [], [], []
 
-            BatchRule(
-                batcher=batcher,
-                this_library=str(rglb),
-                libraryrun_srv=libraryrun_srv
-            ).must_not_have_succeeded_runs()
+    subjects = _extract_unique_subjects(meta_list_df)
 
-        except LabMetadataRuleError as me:
-            logger.warning(f"SKIP {WorkflowType.DRAGEN_WTS.value} workflow for '{rgsm}_{rglb}'. {me}")
-            continue
+    logger.info(f"Preparing Dragen WTS for subjects {subjects}")
 
-        except BatchRuleError as be:
-            logger.warning(f"SKIP {be}")
-            continue
+    # iterate through each sample group by the library id
+    # we use the drop_duplicates so that if there are libraries split across multiple lanes,
+    # the get_metadata_by_library_id will collect this.
+    for index, row in meta_list_df[["subject_id", "library_id"]].drop_duplicates().iterrows():
 
-        # Update read 1 and read 2 strings to cwl file paths
-        rglb_df["read_1"] = rglb_df["read_1"].apply(liborca.cwl_file_path_as_string_to_dict)
-        rglb_df["read_2"] = rglb_df["read_2"].apply(liborca.cwl_file_path_as_string_to_dict)
+        fastq_list_rows = fastq_srv.get_fastq_list_row_by_rglb(row.library_id)
 
-        job = {
-            "library_id": f"{rglb}",
-            "fastq_list_rows": rglb_df.to_dict(orient="records"),
-            "seq_run_id": batcher.sqr.run_id if batcher.sqr else None,
-            "seq_name": batcher.sqr.name if batcher.sqr else None,
-            "batch_run_id": int(batcher.batch_run.id)
-        }
+        # Check library id for rerun
+        fastq_list_rows = _handle_rerun(fastq_list_rows, row.library_id)
 
-        job_list.append(job)
+        job_list.append(create_wts_job(fastq_list_rows, subject_id=row.subject_id, library_id=row.library_id))
+        submitting_subjects.append(job_list)
 
-    return job_list
+    return job_list, subjects, submitting_subjects
+
+
+def create_wts_job(fastq_list_rows: List[FastqListRow], subject_id: str, library_id: str) -> Dict:
+    # Get fastq list rows into dict format
+    fqlr = pd.DataFrame([fq_list_row.to_dict() for fq_list_row in fastq_list_rows]).to_dict(orient="records")
+
+    # create WTS job definition
+    job_dict = {
+        "subject_id": subject_id,
+        "library_id": library_id,
+        "fastq_list_rows": fqlr
+    }
+
+    return job_dict

--- a/data_processors/pipeline/orchestration/tests/test_dragen_wgs_qc_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_wgs_qc_step.py
@@ -123,7 +123,7 @@ class DragenWgsQcStepUnitTests(PipelineUnitTestCase):
         for br in BatchRun.objects.all():
             logger.info(f"BATCH_RUN: {br}")
 
-        wgs_qc_batch_runs = [br for br in BatchRun.objects.all() if br.step == WorkflowType.DRAGEN_WGS_QC.value]
+        wgs_qc_batch_runs = [br for br in BatchRun.objects.all() if br.step == WorkflowType.DRAGEN_WGTS_QC.value]
 
         self.assertTrue(wgs_qc_batch_runs[0].running)
 

--- a/data_processors/pipeline/orchestration/tests/test_dragen_wts_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_wts_step.py
@@ -1,61 +1,20 @@
 import json
-from datetime import datetime
 from unittest import skip
 
-from django.utils.timezone import make_aware, now
+from django.utils.timezone import now
 from libica.app import wes
-from libica.openapi import libwes
-from mockito import when
 
-from data_portal.models.batch import Batch
-from data_portal.models.batchrun import BatchRun
 from data_portal.models.fastqlistrow import FastqListRow
-from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType, LabMetadataWorkflow
+from data_portal.models.labmetadata import LabMetadata
 from data_portal.models.libraryrun import LibraryRun
 from data_portal.models.workflow import Workflow
 from data_portal.tests.factories import WorkflowFactory, TestConstant, DragenWtsQcWorkflowFactory, \
-    WtsTumorLibraryRunFactory, LibraryRunFactory
+    WtsTumorLibraryRunFactory, WtsTumorLabMetadataFactory
 from data_processors.pipeline.domain.batch import Batcher
 from data_processors.pipeline.domain.workflow import WorkflowStatus, WorkflowType
 from data_processors.pipeline.orchestration import fastq_update_step, dragen_wts_step
-from data_processors.pipeline.services import batch_srv, fastq_srv
+from data_processors.pipeline.services import batch_srv, fastq_srv, libraryrun_srv
 from data_processors.pipeline.tests.case import PipelineIntegrationTestCase, PipelineUnitTestCase, logger
-
-wts_mock_subject_id = "SBJ00001"
-mock_library_id = "LPRJ200438"
-mock_sample_id = "PRJ200438"
-mock_sample_name = f"{mock_sample_id}_{mock_library_id}"
-tumor_fastq_list_rows = []
-
-
-def build_wts_mock():
-    mock_wfl_run = libwes.WorkflowRun()
-    mock_wfl_run.id = TestConstant.wfr_id.value
-    mock_wfl_run.status = WorkflowStatus.SUCCEEDED.value
-    mock_wfl_run.time_stopped = make_aware(datetime.utcnow())
-    mock_wfl_run.output = {}
-    workflow_version: libwes.WorkflowVersion = libwes.WorkflowVersion()
-    workflow_version.id = TestConstant.wfv_id.value
-    mock_wfl_run.workflow_version = workflow_version
-    when(libwes.WorkflowRunsApi).get_workflow_run(...).thenReturn(mock_wfl_run)
-
-    mock_labmetadata_tumor = LabMetadata()
-    mock_labmetadata_tumor.subject_id = wts_mock_subject_id
-    mock_labmetadata_tumor.library_id = mock_library_id
-    mock_labmetadata_tumor.phenotype = LabMetadataPhenotype.TUMOR.value
-    mock_labmetadata_tumor.type = LabMetadataType.WTS.value
-    mock_labmetadata_tumor.workflow = LabMetadataWorkflow.CLINICAL.value
-    mock_labmetadata_tumor.save()
-
-    mock_flr_tumor = FastqListRow()
-    mock_flr_tumor.lane = 2
-    mock_flr_tumor.rglb = TestConstant.library_id_tumor.value
-    mock_flr_tumor.rgsm = TestConstant.sample_id.value
-    mock_flr_tumor.rgid = f"AACTCACC.2.350702_A00130_0137_AH5KMHDSXY.{mock_flr_tumor.rgsm}_{mock_flr_tumor.rglb}"
-    mock_flr_tumor.read_1 = "gds://volume/path/tumor_read_1.fastq.gz"
-    mock_flr_tumor.read_2 = "gds://volume/path/tumor_read_2.fastq.gz"
-    mock_flr_tumor.save()
-    tumor_fastq_list_rows.append(mock_flr_tumor)
 
 
 class DragenWtsStepUnitTests(PipelineUnitTestCase):
@@ -65,8 +24,6 @@ class DragenWtsStepUnitTests(PipelineUnitTestCase):
         python manage.py test data_processors.pipeline.orchestration.tests.test_dragen_wts_step.DragenWtsStepUnitTests.test_perform
         """
         self.verify_local()
-
-        build_wts_mock()
 
         mock_dragen_wts_qc_workflow: Workflow = DragenWtsQcWorkflowFactory()
         mock_dragen_wts_qc_workflow.end_status = WorkflowStatus.SUCCEEDED.value
@@ -85,14 +42,30 @@ class DragenWtsStepUnitTests(PipelineUnitTestCase):
             }
         })
         mock_dragen_wts_qc_workflow.save()
-        mock_lbr_normal: LibraryRun = LibraryRunFactory()
-        mock_lbr_tumor: LibraryRun = WtsTumorLibraryRunFactory()
+
+        mock_fqlr_wts_tumor = FastqListRow()
+        mock_fqlr_wts_tumor.lane = 2
+        mock_fqlr_wts_tumor.rglb = TestConstant.wts_library_id_tumor.value
+        mock_fqlr_wts_tumor.rgsm = TestConstant.wts_sample_id.value
+        mock_fqlr_wts_tumor.rgid = f"AACTCACC.2.350702_A00130_0137_AH5KMHDSXY.{mock_fqlr_wts_tumor.rgsm}_{mock_fqlr_wts_tumor.rglb}"
+        mock_fqlr_wts_tumor.read_1 = "gds://volume/path/tumor_read_1.fastq.gz"
+        mock_fqlr_wts_tumor.read_2 = "gds://volume/path/tumor_read_2.fastq.gz"
+        mock_fqlr_wts_tumor.save()
+
+        mock_meta_wts_tumor: LabMetadata = WtsTumorLabMetadataFactory()
+        mock_lbr_wts_tumor: LibraryRun = WtsTumorLibraryRunFactory()
+
+        _ = libraryrun_srv.link_library_run_with_workflow(
+            library_id=mock_lbr_wts_tumor.library_id,
+            lane=mock_lbr_wts_tumor.lane,
+            workflow=mock_dragen_wts_qc_workflow,
+        )
 
         results = dragen_wts_step.perform(this_workflow=mock_dragen_wts_qc_workflow)
         self.assertIsNotNone(results)
 
         logger.info(f"{json.dumps(results)}")
-        self.assertEqual(results['submitting_subjects'][0], wts_mock_subject_id)
+        self.assertEqual(results['subjects'][0], TestConstant.subject_id.value)
 
 
 class DragenWtsStepIntegrationTests(PipelineIntegrationTestCase):

--- a/data_processors/pipeline/orchestration/tests/test_somalier_extract_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_somalier_extract_step.py
@@ -6,7 +6,7 @@ from libumccr import libjson
 from mockito import when
 
 from data_portal.models.workflow import Workflow
-from data_portal.tests.factories import DragenWgsQcWorkflowFactory
+from data_portal.tests.factories import DragenWgtsQcWorkflowFactory
 from data_processors.pipeline.domain.workflow import WorkflowStatus, WorkflowType
 from data_processors.pipeline.orchestration import somalier_extract_step
 from data_processors.pipeline.tests.case import PipelineUnitTestCase, logger
@@ -64,7 +64,7 @@ mock_wgs_output = json.dumps({
 
 
 def build_wgs_qc_mock():
-    mock_wgc_qc_workflow: Workflow = DragenWgsQcWorkflowFactory()
+    mock_wgc_qc_workflow: Workflow = DragenWgtsQcWorkflowFactory()
     mock_wgc_qc_workflow.wfr_id = mock_wgs_workflow_id
     mock_wgc_qc_workflow.output = mock_wgs_output
     mock_wgc_qc_workflow.end = now()

--- a/data_processors/pipeline/orchestration/tests/test_somalier_extract_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_somalier_extract_step.py
@@ -6,7 +6,7 @@ from libumccr import libjson
 from mockito import when
 
 from data_portal.models.workflow import Workflow
-from data_portal.tests.factories import DragenWgtsQcWorkflowFactory
+from data_portal.tests.factories import DragenWgsQcWorkflowFactory
 from data_processors.pipeline.domain.workflow import WorkflowStatus, WorkflowType
 from data_processors.pipeline.orchestration import somalier_extract_step
 from data_processors.pipeline.tests.case import PipelineUnitTestCase, logger
@@ -64,7 +64,7 @@ mock_wgs_output = json.dumps({
 
 
 def build_wgs_qc_mock():
-    mock_wgc_qc_workflow: Workflow = DragenWgtsQcWorkflowFactory()
+    mock_wgc_qc_workflow: Workflow = DragenWgsQcWorkflowFactory()
     mock_wgc_qc_workflow.wfr_id = mock_wgs_workflow_id
     mock_wgc_qc_workflow.output = mock_wgs_output
     mock_wgc_qc_workflow.end = now()

--- a/data_processors/pipeline/orchestration/tests/test_tumor_normal_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_tumor_normal_step.py
@@ -10,7 +10,7 @@ from data_portal.models.fastqlistrow import FastqListRow
 from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType, LabMetadataWorkflow
 from data_portal.models.libraryrun import LibraryRun
 from data_portal.models.workflow import Workflow
-from data_portal.tests.factories import TestConstant, DragenWgsQcWorkflowFactory, LibraryRunFactory, \
+from data_portal.tests.factories import TestConstant, DragenWgtsQcWorkflowFactory, DragenWgsQcWorkflowFactory, LibraryRunFactory, \
     TumorLibraryRunFactory
 from data_processors.pipeline.domain.config import ICA_WORKFLOW_PREFIX
 from data_processors.pipeline.domain.workflow import WorkflowStatus

--- a/data_processors/pipeline/orchestration/tumor_normal_step.py
+++ b/data_processors/pipeline/orchestration/tumor_normal_step.py
@@ -19,7 +19,7 @@ from data_processors.pipeline.orchestration import _reduce_and_transform_to_df, 
     _mint_libraries
 from data_processors.pipeline.services import workflow_srv, metadata_srv, fastq_srv
 from data_processors.pipeline.tools import liborca
-from data_processors.pipeline.tools.liborca import _handle_rerun
+from data_processors.pipeline.orchestration import _handle_rerun
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/data_processors/pipeline/services/tests/test_metadata_srv.py
+++ b/data_processors/pipeline/services/tests/test_metadata_srv.py
@@ -4,7 +4,7 @@ from data_portal.models.labmetadata import LabMetadata
 from data_portal.models.libraryrun import LibraryRun
 from data_portal.models.sequencerun import SequenceRun
 from data_portal.tests import factories
-from data_portal.tests.factories import TestConstant, LibraryRunFactory, DragenWgsQcWorkflowFactory, LabMetadataFactory, \
+from data_portal.tests.factories import TestConstant, LibraryRunFactory, DragenWgtsQcWorkflowFactory, LabMetadataFactory, \
     TumorLabMetadataFactory, TumorLibraryRunFactory
 from data_processors.pipeline.services import metadata_srv, libraryrun_srv
 from data_processors.pipeline.tests.case import logger, PipelineUnitTestCase
@@ -55,7 +55,7 @@ class MetadataSrvUnitTests(PipelineUnitTestCase):
         """
         mock_meta: LabMetadata = factories.LabMetadataFactory()
         mock_library_run: LibraryRun = LibraryRunFactory()
-        mock_workflow = DragenWgsQcWorkflowFactory()
+        mock_workflow = DragenWgtsQcWorkflowFactory()
         _ = libraryrun_srv.link_library_runs_with_x_seq_workflow(
             library_id_list=[mock_library_run.library_id],
             workflow=mock_workflow

--- a/data_processors/pipeline/tools/liborca.py
+++ b/data_processors/pipeline/tools/liborca.py
@@ -470,3 +470,14 @@ def parse_tso_ctdna_output_for_bam_file(workflow_output_json: str, deep_check: b
             raise ValueError(f"Couldn't get bam file from tso_ctdna_tumor_only output directory '{main_bam_path}'")
 
         return main_bam_path
+
+
+def _handle_rerun(fastq_list_rows: List[FastqListRow], library_id):
+    for fastq_list_row in fastq_list_rows:
+        full_sample_library_id = fastq_list_row.rgid.rsplit(".", 1)[-1]
+        if liborca.sample_library_id_has_rerun(full_sample_library_id):
+            logger.warning(f"We found a rerun for library id {library_id} in {full_sample_library_id}. "
+                           f"Please run this sample manually")
+            # Reset fastq list rows - we don't know what to do with reruns
+            return []
+    return fastq_list_rows

--- a/data_processors/pipeline/tools/liborca.py
+++ b/data_processors/pipeline/tools/liborca.py
@@ -470,14 +470,3 @@ def parse_tso_ctdna_output_for_bam_file(workflow_output_json: str, deep_check: b
             raise ValueError(f"Couldn't get bam file from tso_ctdna_tumor_only output directory '{main_bam_path}'")
 
         return main_bam_path
-
-
-def _handle_rerun(fastq_list_rows: List[FastqListRow], library_id):
-    for fastq_list_row in fastq_list_rows:
-        full_sample_library_id = fastq_list_row.rgid.rsplit(".", 1)[-1]
-        if liborca.sample_library_id_has_rerun(full_sample_library_id):
-            logger.warning(f"We found a rerun for library id {library_id} in {full_sample_library_id}. "
-                           f"Please run this sample manually")
-            # Reset fastq list rows - we don't know what to do with reruns
-            return []
-    return fastq_list_rows


### PR DESCRIPTION
# cba747810c875ad9c4a919c16b62bdbb3cca6be8

> Updates by file

## data_processors.pipeline.domain.workflow.py

* Added abstract workflow type DRAGEN_WGTS_QC.
* Added labmetadata rule method must_be_wgts

## data_processors.pipeline.lambdas.dragen_wgs_qc.py

* Handle WTS data and add enable_rna option. True for WTS data, false for WGS data

## data_processors.pipeline.orchestartion.dragen_wgs_qc_step.py

* Set batcher runstep parameter to DRAGEN_WGTS_QC abstract workflow type
* Replace must_be_wgs labmetadata rule with must_be_wgts
* Update warning to use DRAGEN_WGTS_QC  abstract workflow type

# 5eb62f375ff69f5bb4066ce5b065afb62c262635

> Update orchestration logic

* Now dragen wts happens after QC is complete.

* Instead of performing dragen_wts after bclconvert, we first run dragen_wgts_qc (which now includes dragen_wts samples).