### PR TITLE
[STG] Added LabMetadata processing for 2018 and 2017 sheets

### DIFF
--- a/data_processors/lims/lambdas/labmetadata.py
+++ b/data_processors/lims/lambdas/labmetadata.py
@@ -31,7 +31,7 @@ def _halt(msg):
 def scheduled_update_handler(event, context):
     """event payload dict
     {
-        'sheets': ["2019", "2020", "2021", "2022", "2023"],
+        'sheets': ["2017", "2018", "2019", "2020", "2021", "2022", "2023"],
         'truncate': True
     }
     Handler for LabMetadata update by reading the designated Spreadsheet file from Google Drive.
@@ -52,7 +52,7 @@ def scheduled_update_handler(event, context):
     requested_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     logger.info(f"Reading LabMetadata sheet from google drive at {requested_time}")
 
-    years = event.get('sheets', ["2019", "2020", "2021", "2022", "2023"])
+    years = event.get('sheets', ["2017", "2018", "2019", "2020", "2021", "2022", "2023"])
     is_truncate = event.get('truncate', True)
 
     if not isinstance(years, list):

--- a/serverless.yml
+++ b/serverless.yml
@@ -127,7 +127,7 @@ functions:
       - schedule:
           rate: cron(0 12 * * ? *)
           enabled: ${self:custom.enabled.${self:provider.stage}, self:custom.enabled.other}
-    timeout: 240
+    timeout: 360
 
   labmetadata_scheduled_update_processor:
     handler: data_processors.lims.lambdas.labmetadata.scheduled_update_handler
@@ -137,7 +137,7 @@ functions:
       - schedule:
           rate: cron(0 12 * * ? *)
           enabled: ${self:custom.enabled.${self:provider.stage}, self:custom.enabled.other}
-    timeout: 240
+    timeout: 360
 
   sqs_s3_event_processor:
     handler: data_processors.s3.lambdas.s3_event.handler


### PR DESCRIPTION
* As a part of PDAC cohort reprocessing, we refill legacy library and sample metadata from early sequencing runs circa 2017, 2018
* Bumped timeout for more headroom