### PR TITLE
Improved FastqListRow lookup filter by specific SequenceRun instance

### DIFF
--- a/data_processors/pipeline/domain/batch.py
+++ b/data_processors/pipeline/domain/batch.py
@@ -55,7 +55,7 @@ class Batcher:
     def _prepare_batch_context(self):
         if self.batch.context_data is None:
             # cache batch context data in db
-            fastq_list_rows = self.fastq_srv.get_fastq_list_row_by_sequence_name(self.sqr.name)
+            fastq_list_rows = self.fastq_srv.get_fastq_list_row_by_sequence_run(self.sqr)
             self.batch = self.batch_srv.update_batch(self.batch.id, context_data=fastq_list_rows)
 
     # --- external behaviours

--- a/data_processors/pipeline/domain/tests/test_batch.py
+++ b/data_processors/pipeline/domain/tests/test_batch.py
@@ -1,0 +1,47 @@
+from data_portal.models import Workflow, FastqListRow, Batch, BatchRun
+from data_portal.tests.factories import WorkflowFactory
+from data_processors.pipeline.domain.batch import Batcher
+from data_processors.pipeline.domain.workflow import WorkflowType, WorkflowStatus
+from data_processors.pipeline.services import batch_srv, fastq_srv
+from data_processors.pipeline.tests.case import PipelineUnitTestCase, logger
+
+
+class BatcherUnitTests(PipelineUnitTestCase):
+
+    def setUp(self) -> None:
+        super(BatcherUnitTests, self).setUp()
+
+    def test_batching(self):
+        """
+        python manage.py test data_processors.pipeline.domain.tests.test_batch.BatcherUnitTests.test_batching
+        """
+        mock_bcl_convert: Workflow = WorkflowFactory()
+        mock_bcl_convert.end_status = WorkflowStatus.SUCCEEDED.value
+        mock_bcl_convert.save()
+
+        mock_sqr = mock_bcl_convert.sequence_run
+
+        mock_fqlr = FastqListRow()
+        mock_fqlr.rgid = f"TCCGGAGA.AGGATAGG.1.{mock_sqr.name}.PRJ123456_L1234567"
+        mock_fqlr.rglb = "L1234567"
+        mock_fqlr.rgsm = "PRJ123456"
+        mock_fqlr.lane = 1
+        mock_fqlr.read_1 = f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R1_001.fastq.gz"
+        mock_fqlr.read_2 = f"gds://umccr-fastq-data/{mock_sqr.name}/A/UMCCR/PRJ123456_L1234567_S1_L001_R2_001.fastq.gz"
+        mock_fqlr.sequence_run = mock_sqr
+        mock_fqlr.save()
+
+        mock_batcher = Batcher(
+            workflow=mock_bcl_convert,
+            run_step=WorkflowType.DRAGEN_WGTS_QC.value,
+            batch_srv=batch_srv,
+            fastq_srv=fastq_srv,
+            logger=logger,
+        )
+
+        self.assertIsNotNone(mock_batcher)
+        logger.info(mock_batcher.get_status())
+        logger.info(mock_batcher.batch.context_data)
+
+        self.assertEqual(1, Batch.objects.count())
+        self.assertEqual(1, BatchRun.objects.count())

--- a/data_processors/pipeline/services/fastq_srv.py
+++ b/data_processors/pipeline/services/fastq_srv.py
@@ -64,8 +64,17 @@ def create_or_update_fastq_list_row(fastq_list_row: dict, sequence_run: Sequence
 
 
 @transaction.atomic
-def get_fastq_list_row_by_sequence_name(sequence_name):
-    qs = FastqListRow.objects.filter(sequence_run__name__iexact=sequence_name)
+def get_fastq_list_row_by_sequence_run(sqr: SequenceRun):
+    """
+    Business logic:
+    Find FastqListRow records by linked SequenceRun instance
+    Note, it is safer to perform lookup filter by specific SequenceRun instance
+    as there can be multiple SequenceRun entries of the same instrument_run_id or sequence name (i.e. event replay)
+
+    This is particularly important in a case re-run with "subset" of BCL Convert output only, such as follows.
+    https://umccr.slack.com/archives/C8CG6K76W/p1690351136620419
+    """
+    qs = FastqListRow.objects.filter(sequence_run=sqr)
     if qs.exists():
         fqlr_list = []
         for fqlr in qs.all():

--- a/data_processors/pipeline/services/tests/test_fastq_srv.py
+++ b/data_processors/pipeline/services/tests/test_fastq_srv.py
@@ -14,9 +14,9 @@ class FastqSrvUnitTests(PipelineUnitTestCase):
     def setUp(self) -> None:
         super(FastqSrvUnitTests, self).setUp()
 
-    def test_get_fastq_list_row_by_sequence_name(self):
+    def test_get_fastq_list_row_by_sequence_run(self):
         """
-        python manage.py test data_processors.pipeline.services.tests.test_fastq_srv.FastqSrvUnitTests.test_get_fastq_list_row_by_sequence_name
+        python manage.py test data_processors.pipeline.services.tests.test_fastq_srv.FastqSrvUnitTests.test_get_fastq_list_row_by_sequence_run
         """
 
         mock_sqr: SequenceRun = factories.SequenceRunFactory()
@@ -31,7 +31,7 @@ class FastqSrvUnitTests(PipelineUnitTestCase):
         mock_fqlr.sequence_run = mock_sqr
         mock_fqlr.save()
 
-        fqlr_list = fastq_srv.get_fastq_list_row_by_sequence_name(mock_sqr.name)
+        fqlr_list = fastq_srv.get_fastq_list_row_by_sequence_run(mock_sqr)
         logger.info(libjson.dumps(fqlr_list))
         self.assertTrue(isinstance(fqlr_list, List))
         self.assertTrue(isinstance(fqlr_list[0]['read_1'], str))  # assert that it is not transformed CWL File object


### PR DESCRIPTION
* Removed ambiguous lookup filter by sequence name
* When we have BSSH event replay with "subset" SampleSheet.csv, the linked
  FastqListRow will be reduced accordingly for this new BSSH SequenceRun
  entry. Hence, when looking up by just instrument_run_id or sequence name
  would cause detrimental side effect by using all of previous sequence runs.
