### PR TITLE
Refactored WorkflowHelper portal_run_id generator to use IdHelper

### DIFF
--- a/data_processors/pipeline/domain/tests/test_workflow.py
+++ b/data_processors/pipeline/domain/tests/test_workflow.py
@@ -7,7 +7,7 @@ from data_portal.models.workflow import Workflow
 from data_portal.tests import factories
 from data_portal.tests.factories import SequenceFactory, TestConstant
 from data_processors.pipeline.domain.workflow import WorkflowRule, WorkflowType, SecondaryAnalysisHelper, \
-    PrimaryDataHelper, SequenceRule, SequenceRuleError
+    PrimaryDataHelper, SequenceRule, SequenceRuleError, WorkflowHelper
 from data_processors.pipeline.tests.case import logger, PipelineUnitTestCase
 
 
@@ -15,6 +15,16 @@ class WorkflowDomainUnitTests(PipelineUnitTestCase):
 
     def setUp(self) -> None:
         super(WorkflowDomainUnitTests, self).setUp()
+
+    def test_portal_run_id(self):
+        """
+        python manage.py test data_processors.pipeline.domain.tests.test_workflow.WorkflowDomainUnitTests.test_portal_run_id
+        """
+        helper = WorkflowHelper(WorkflowType.BCL_CONVERT)
+        logger.info(helper.get_portal_run_id())
+        self.assertIsNotNone(helper.portal_run_id)
+        self.assertEqual(len(helper.portal_run_id), 16)
+        self.assertEqual(helper.get_portal_run_id(), helper.portal_run_id)
 
     def test_secondary_analysis_helper(self):
         """

--- a/data_processors/pipeline/domain/tests/test_workflow.py
+++ b/data_processors/pipeline/domain/tests/test_workflow.py
@@ -21,10 +21,12 @@ class WorkflowDomainUnitTests(PipelineUnitTestCase):
         python manage.py test data_processors.pipeline.domain.tests.test_workflow.WorkflowDomainUnitTests.test_portal_run_id
         """
         helper = WorkflowHelper(WorkflowType.BCL_CONVERT)
-        logger.info(helper.get_portal_run_id())
+        helper2 = WorkflowHelper(WorkflowType.TUMOR_NORMAL)
+        logger.info(f"{helper.get_portal_run_id()} != {helper2.get_portal_run_id()}")
         self.assertIsNotNone(helper.portal_run_id)
         self.assertEqual(len(helper.portal_run_id), 16)
         self.assertEqual(helper.get_portal_run_id(), helper.portal_run_id)
+        self.assertNotEquals(helper.portal_run_id, helper2.portal_run_id)
 
     def test_secondary_analysis_helper(self):
         """

--- a/data_processors/pipeline/domain/workflow.py
+++ b/data_processors/pipeline/domain/workflow.py
@@ -8,14 +8,13 @@ See orchestration package __init__.py doc string.
 import copy
 import logging
 from abc import ABC, abstractmethod
-from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from uuid import uuid4
 
 from libumccr import libjson
 from libumccr.aws import libssm
 
+from data_portal.fields import IdHelper
 from data_processors.pipeline.domain.config import ICA_WORKFLOW_PREFIX
 
 logger = logging.getLogger(__name__)
@@ -83,8 +82,7 @@ class WorkflowHelper(ABC):
 
     def __init__(self, type_: WorkflowType):
         self.type = type_
-        self.date_time = datetime.utcnow()
-        self.portal_run_id = f"{self.date_time.strftime('%Y%m%d')}{str(uuid4())[:8]}"
+        self.portal_run_id = IdHelper.generate_portal_run_id()
 
     def get_portal_run_id(self) -> str:
         return self.portal_run_id
@@ -250,7 +248,6 @@ class ExternalWorkflowHelper(WorkflowHelper):
         if type_ not in allowed_workflow_types:
             raise ValueError(f"Unsupported WorkflowType for external analysis: {type_}")
         super().__init__(type_)
-
 
 
 class SequenceRuleError(ValueError):


### PR DESCRIPTION
The `portal_run_id` generator has been pushed up (promoted) to higher order construct `IdHelper`