### PR TITLE
Removed serverless domain manager stage variable

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -29,6 +29,6 @@ phases:
       - make load_localstack
       - python manage.py test
       - docker-compose -f docker-compose.yml -f docker-compose.ci.yml down
-      - npx serverless create_domain --stage $STAGE
+      - npx serverless create_domain
       - npx serverless deploy --stage $STAGE
       - npx serverless invoke -f migrate --stage $STAGE

--- a/serverless.yml
+++ b/serverless.yml
@@ -475,7 +475,8 @@ custom:
     - http:
         domainName: ${ssm:/data_portal/backend/api_domain_name}
         basePath: ''
-        stage: ${self:provider.stage}
+        # Either set the stage to proper one or use the APIGateway v2 $default value
+#        stage: ${self:provider.stage}
         createRoute53Record: true
         certificateArn: ${ssm:/data_portal/backend/certificate_arn}
         apiType: http
@@ -483,7 +484,7 @@ custom:
     - http:
         domainName: ${ssm:/data_portal/backend/api_domain_name2}
         basePath: ''
-        stage: ${self:provider.stage}
+#        stage: ${self:provider.stage}
         createRoute53Record: true
         certificateArn: ${ssm:/data_portal/backend/certificate_arn2}
         apiType: http


### PR DESCRIPTION
* We need to either set the stage variable to a proper one or
  use the APIGateway v2 `$default` value. Otherwise, it throws
  "V2 - Unable to update base path mapping ...". See
  https://github.com/amplify-education/serverless-domain-manager/blob/1a0e72c/src/aws/api-gateway-v2-wrapper.ts#L177-L198
