### PR TITLE
Improved SQS Lambda handler partial batch responses - ReportBatchItemFailures

### DIFF
--- a/data_processors/pipeline/domain/workflow.py
+++ b/data_processors/pipeline/domain/workflow.py
@@ -208,7 +208,7 @@ class SecondaryAnalysisHelper(IcaWorkflowHelper):
     def __init__(self, type_: WorkflowType):
         allowed_workflow_types = [
             WorkflowType.DRAGEN_WGS_QC,
-            WorkflowType.DRAGEN_WGTS_QC,
+            # WorkflowType.DRAGEN_WGTS_QC,  # intentional comment, do not initialise a placeholder type, see ^^^
             WorkflowType.DRAGEN_WTS_QC,
             WorkflowType.DRAGEN_TSO_CTDNA,
             WorkflowType.DRAGEN_WTS,
@@ -217,7 +217,7 @@ class SecondaryAnalysisHelper(IcaWorkflowHelper):
             WorkflowType.RNASUM
         ]
         if type_ not in allowed_workflow_types:
-            raise ValueError(f"Unsupported WorkflowType for Secondary analysis: {type_}")
+            raise ValueError(f"Unsupported WorkflowType for Secondary Analysis: {type_}")
         super().__init__(type_)
 
     def get_mid_path(self, target_id: str, secondary_target_id: str = None) -> str:

--- a/data_processors/pipeline/lambdas/dragen_tso_ctdna.py
+++ b/data_processors/pipeline/lambdas/dragen_tso_ctdna.py
@@ -50,12 +50,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/dragen_wgs_qc.py
+++ b/data_processors/pipeline/lambdas/dragen_wgs_qc.py
@@ -121,21 +121,19 @@ def handler(event, context) -> dict:
 
     # Check type is not None
     if library_lab_metadata is None:
-        logger.error(f"Expected to retrieve metadata for library '{library_id}' but no metadata was returned")
-        raise ValueError
+        raise ValueError(f"Metadata not found for library_id '{library_id}'")
 
     # ###
     # Read the following step module doc string about workflow typing
     # `data_processors.pipeline.orchestration.dragen_wgs_qc_step`
     # ###
     # Get workflow helper
-    if library_lab_metadata.type == LabMetadataType.WTS:
+    if library_lab_metadata.type.lower() == LabMetadataType.WTS.value.lower():
         workflow_type = WorkflowType.DRAGEN_WTS_QC
-    elif library_lab_metadata.type == LabMetadataType.WGS:
+    elif library_lab_metadata.type.lower() == LabMetadataType.WGS.value.lower():
         workflow_type = WorkflowType.DRAGEN_WGS_QC
     else:
-        logger.error(f"Expected metadata type for library id '{library_id}' to be one of WGS or WTS")
-        raise ValueError
+        raise ValueError(f"Expected metadata type for library_id '{library_id}' to be one of WGS or WTS")
 
     wfl_helper = SecondaryAnalysisHelper(workflow_type)
     workflow_input: dict = wfl_helper.get_workflow_input()

--- a/data_processors/pipeline/lambdas/dragen_wgs_qc.py
+++ b/data_processors/pipeline/lambdas/dragen_wgs_qc.py
@@ -50,12 +50,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/dragen_wts.py
+++ b/data_processors/pipeline/lambdas/dragen_wts.py
@@ -1,4 +1,3 @@
-
 try:
     import unzip_requirements
 except ImportError:
@@ -54,12 +53,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/notification.py
+++ b/data_processors/pipeline/lambdas/notification.py
@@ -46,12 +46,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
-        m = libjson.loads(message['body'])
-        results.append(handler(m, context))
+        job = libjson.loads(message['body'])
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/oncoanalyser_wgs.py
+++ b/data_processors/pipeline/lambdas/oncoanalyser_wgs.py
@@ -53,12 +53,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/oncoanalyser_wgts_existing_both.py
+++ b/data_processors/pipeline/lambdas/oncoanalyser_wgts_existing_both.py
@@ -53,12 +53,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/oncoanalyser_wts.py
+++ b/data_processors/pipeline/lambdas/oncoanalyser_wts.py
@@ -53,12 +53,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/sash.py
+++ b/data_processors/pipeline/lambdas/sash.py
@@ -54,12 +54,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/somalier_extract.py
+++ b/data_processors/pipeline/lambdas/somalier_extract.py
@@ -48,12 +48,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/star_alignment.py
+++ b/data_processors/pipeline/lambdas/star_alignment.py
@@ -53,12 +53,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/tests/test_dragen_tso_ctdna.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_tso_ctdna.py
@@ -212,7 +212,7 @@ class DragenTsoCtDnaTests(PipelineUnitTestCase):
         logger.info("Example dragen_tso_ctdna.sqs_handler lambda output:")
         logger.info(json.dumps(results))
 
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
 
 
 class DragenTsoCtDnaIntegrationTests(PipelineIntegrationTestCase):

--- a/data_processors/pipeline/lambdas/tests/test_dragen_tso_ctdna.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_tso_ctdna.py
@@ -212,6 +212,9 @@ class DragenTsoCtDnaTests(PipelineUnitTestCase):
         logger.info("Example dragen_tso_ctdna.sqs_handler lambda output:")
         logger.info(json.dumps(results))
 
+        # expecting length of 2 in results
+        # i.e. one for the handler results and one for the batchItemFailures
+        # No matter what, both should always be present.
         self.assertEqual(len(results), 2)
 
 

--- a/data_processors/pipeline/lambdas/tests/test_dragen_wgs_qc.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_wgs_qc.py
@@ -233,6 +233,9 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
         logger.info("Example dragen_wgs_qc.sqs_handler lambda output:")
         logger.info(json.dumps(results))
 
+        # expecting length of 2 in results
+        # i.e. one for the handler results and one for the batchItemFailures
+        # No matter what, both should always be present.
         self.assertEqual(len(results), 2)
 
     def test_portal_run_id(self):

--- a/data_processors/pipeline/lambdas/tests/test_dragen_wgs_qc.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_wgs_qc.py
@@ -165,7 +165,7 @@ class DragenWgsQcUnitTests(PipelineUnitTestCase):
         logger.info("Example dragen_wgs_qc.sqs_handler lambda output:")
         logger.info(json.dumps(results))
 
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
 
     def test_portal_run_id(self):
         """

--- a/data_processors/pipeline/lambdas/tests/test_dragen_wgs_qc.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_wgs_qc.py
@@ -6,6 +6,8 @@ from libica.openapi import libwes
 from libumccr import libjson
 from mockito import when
 
+from data_portal.models import LabMetadata
+from data_portal.models.labmetadata import LabMetadataType
 from data_portal.models.libraryrun import LibraryRun
 from data_portal.models.sequencerun import SequenceRun
 from data_portal.models.workflow import Workflow
@@ -18,6 +20,72 @@ from data_processors.pipeline.tests.case import logger, PipelineUnitTestCase, Pi
 
 
 class DragenWgsQcUnitTests(PipelineUnitTestCase):
+
+    def test_handler_no_meta(self):
+        """
+        python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_wgs_qc.DragenWgsQcUnitTests.test_handler_no_meta
+        """
+
+        with self.assertRaises(ValueError) as cm:
+            dragen_wgs_qc.handler({
+                "library_id": TestConstant.library_id_normal.value,
+                "lane": TestConstant.lane_normal_library.value,
+                "fastq_list_rows": [
+                    {
+                        "rgid": "index1.index2.lane",
+                        "rgsm": "sample_name",
+                        "rglb": "L0000001",
+                        "lane": 1,
+                        "read_1": {
+                            "class": "File",
+                            "location": "gds://path/to/read_1.fastq.gz"
+                        },
+                        "read_2": {
+                            "class": "File",
+                            "location": "gds://path/to/read_2.fastq.gz"
+                        }
+                    }
+                ],
+            }, None)
+        e = cm.exception
+
+        logger.exception(f"THIS ERROR EXCEPTION IS INTENTIONAL FOR TEST. NOT ACTUAL ERROR. \n{str(e)}")
+        self.assertIn("Metadata not found", str(e))
+
+    def test_handler_wrong_meta_type(self):
+        """
+        python manage.py test data_processors.pipeline.lambdas.tests.test_dragen_wgs_qc.DragenWgsQcUnitTests.test_handler_wrong_meta_type
+        """
+
+        mock_normal_library: LabMetadata = LabMetadataFactory()
+        mock_normal_library.type = LabMetadataType.EXOME
+        mock_normal_library.save()
+
+        with self.assertRaises(ValueError) as cm:
+            dragen_wgs_qc.handler({
+                "library_id": TestConstant.library_id_normal.value,
+                "lane": TestConstant.lane_normal_library.value,
+                "fastq_list_rows": [
+                    {
+                        "rgid": "index1.index2.lane",
+                        "rgsm": "sample_name",
+                        "rglb": "L0000001",
+                        "lane": 1,
+                        "read_1": {
+                            "class": "File",
+                            "location": "gds://path/to/read_1.fastq.gz"
+                        },
+                        "read_2": {
+                            "class": "File",
+                            "location": "gds://path/to/read_2.fastq.gz"
+                        }
+                    }
+                ],
+            }, None)
+        e = cm.exception
+
+        logger.exception(f"THIS ERROR EXCEPTION IS INTENTIONAL FOR TEST. NOT ACTUAL ERROR. \n{str(e)}")
+        self.assertIn("be one of WGS or WTS", str(e))
 
     def test_handler(self):
         """

--- a/data_processors/pipeline/lambdas/tests/test_dragen_wts.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_wts.py
@@ -163,7 +163,7 @@ class DragenWtsUnitTests(PipelineUnitTestCase):
         logger.info("Example dragen_wts.sqs_handler lambda output:")
         logger.info(json.dumps(results))
 
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
 
     def test_override_arriba_fusion_step_resources(self):
         """

--- a/data_processors/pipeline/lambdas/tests/test_dragen_wts.py
+++ b/data_processors/pipeline/lambdas/tests/test_dragen_wts.py
@@ -163,6 +163,9 @@ class DragenWtsUnitTests(PipelineUnitTestCase):
         logger.info("Example dragen_wts.sqs_handler lambda output:")
         logger.info(json.dumps(results))
 
+        # expecting length of 2 in results
+        # i.e. one for the handler results and one for the batchItemFailures
+        # No matter what, both should always be present.
         self.assertEqual(len(results), 2)
 
     def test_override_arriba_fusion_step_resources(self):

--- a/data_processors/pipeline/lambdas/tumor_normal.py
+++ b/data_processors/pipeline/lambdas/tumor_normal.py
@@ -52,12 +52,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/umccrise.py
+++ b/data_processors/pipeline/lambdas/umccrise.py
@@ -50,12 +50,24 @@ def sqs_handler(event, context):
     messages = event['Records']
 
     results = []
+    batch_item_failures = []
     for message in messages:
         job = libjson.loads(message['body'])
-        results.append(handler(job, context))
+        try:
+            results.append(handler(job, context))
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                "itemIdentifier": message['messageId']
+            })
 
     return {
-        'results': results
+        'results': results,
+        'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/services/notification_srv.py
+++ b/data_processors/pipeline/services/notification_srv.py
@@ -257,7 +257,7 @@ def notify_batch_run_status(batch_run_id):
         state = "completed"
 
     workflows = Workflow.objects.get_by_batch_run(batch_run=batch_run)
-    workflow = workflows[0]  # pick one for convenience
+    workflow: Workflow = workflows[0]  # pick one for convenience
 
     _total_cnt = 0
     _stats = {
@@ -295,11 +295,15 @@ def notify_batch_run_status(batch_run_id):
         # anything else -> orange
         _color = libslack.SlackColor.ORANGE.value
 
+    wfl_type = str(workflow.type_name)
+    if wfl_type.lower() in [WorkflowType.DRAGEN_WTS_QC.value.lower(), WorkflowType.DRAGEN_WGS_QC.value.lower()]:
+        wfl_type = WorkflowType.DRAGEN_WGTS_QC.value  # override with placeholder WGTS type for a qc batch as whole
+
     _attachments = [
         {
             "fallback": _topic,
             "color": _color,
-            "pretext": f"Status: {state.upper()}, Workflow: {workflow.type_name.upper()}@{workflow.version}",
+            "pretext": f"Status: {state.upper()}, Workflow: {wfl_type.upper()}@{workflow.version}",
             "title": _title,
             "text": _metrics,
             "footer": SLACK_FOOTER_BADGE_AUTO,

--- a/serverless.yml
+++ b/serverless.yml
@@ -146,6 +146,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/s3_event_sqs_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 120
     reservedConcurrency: 20
     # Uncomment to enable xray on this lambda
@@ -160,6 +161,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/ica_gds_event_sqs_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 120
     reservedConcurrency: 20
 
@@ -170,6 +172,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/batch_event_sqs_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 120
 
   sqs_iap_event_processor:
@@ -179,8 +182,12 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/iap_ens_event_sqs_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 120
 
+  # SQS Implement partial batch responses - ReportBatchItemFailures
+  # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+  # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
   sqs_dragen_wgs_qc_event_processor:
     handler: data_processors.pipeline.lambdas.dragen_wgs_qc.sqs_handler
     layers:
@@ -188,6 +195,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_dragen_wgs_qc_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_dragen_wts_event_processor:
@@ -197,6 +205,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_dragen_wts_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_star_alignment_event_processor:
@@ -206,6 +215,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_star_alignment_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_oncoanalyser_wts_event_processor:
@@ -215,6 +225,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_oncoanalyser_wts_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_oncoanalyser_wgs_event_processor:
@@ -224,6 +235,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_oncoanalyser_wgs_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_oncoanalyser_wgts_existing_both:
@@ -233,6 +245,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_oncoanalyser_wgts_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_sash_event_processor:
@@ -242,6 +255,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_sash_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_dragen_tso_ctdna_event_processor:
@@ -251,6 +265,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_dragen_tso_ctdna_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_tumor_normal_event_processor:
@@ -260,6 +275,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_tumor_normal_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_umccrise_event_processor:
@@ -269,6 +285,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_umccrise_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_rnasum_event_processor:
@@ -278,6 +295,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_rnasum_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   sqs_somalier_extract_event_processor:
@@ -287,6 +305,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_somalier_extract_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 60
 
   sqs_notification_event_processor:
@@ -296,6 +315,7 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/sqs_notification_queue_arn}
+          functionResponseType: ReportBatchItemFailures
     timeout: 28
 
   bcl_convert:


### PR DESCRIPTION
* This feature allows FIFO queue's Lambda trigger to allow partially process
  of messages in a batch and, still keep exception-raised events in the queue.
  Essentially, e.g. total 10 messages; 6 process success and 4 exception raised
  then 6 will clear away from Q; but leave 4 in the Q. Instead of retrying the
  whole batch.

See doc
* https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
* https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures

co-co: @reisingerf
