### PR TITLE
Improved ICA ENS and AWS Batch SQS Lambda handlers response in dict

### DIFF
--- a/data_processors/pipeline/lambdas/sqs_batch_event.py
+++ b/data_processors/pipeline/lambdas/sqs_batch_event.py
@@ -50,25 +50,42 @@ def handler(event, context):
 
     messages = event['Records']
 
+    results = []
+    batch_item_failures = []
     for message in messages:
-        # parse outer SQS event
-        event_source = message['eventSource']
-        if event_source != EventSource.AWS_SQS.value:
-            logger.warning(f"Skipping unsupported event source: {event_source}")
-            continue
 
-        # parse inner Batch event
-        batch_event = json.loads(message['body'], object_hook=lambda d: SimpleNamespace(**d))
-        if batch_event.source == EventSource.AWS_BATCH.value:
-            handle_aws_batch_event(batch_event, context)
+        try:
+            # parse outer SQS event
+            event_source = message['eventSource']
+            if event_source != EventSource.AWS_SQS.value:
+                logger.warning(f"Skipping unsupported event source: {event_source}")
+                continue
 
-        if batch_event.source != EventSource.AWS_BATCH.value:
-            logger.warning(f"Skipping unsupported inner event source: {batch_event.source}")
-            continue
+            # parse inner Batch event
+            batch_event = json.loads(message['body'], object_hook=lambda d: SimpleNamespace(**d))
+            if batch_event.source == EventSource.AWS_BATCH.value:
+                handle_aws_batch_event(batch_event, context)
 
-    _msg = f"AWS Batch event processing complete"
-    logger.info(_msg)
-    return _msg
+            if batch_event.source != EventSource.AWS_BATCH.value:
+                logger.warning(f"Skipping unsupported inner event source: {batch_event.source}")
+                continue
+
+            results.append(message['messageId'])
+
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                'itemIdentifier': message['messageId']
+            })
+
+    return {
+        'results': results,
+        'batchItemFailures': batch_item_failures
+    }
 
 
 def handle_aws_batch_event(batch_event: SimpleNamespace, context):

--- a/data_processors/pipeline/lambdas/sqs_iap_event.py
+++ b/data_processors/pipeline/lambdas/sqs_iap_event.py
@@ -45,25 +45,42 @@ def handler(event, context):
 
     messages = event['Records']
 
+    results = []
+    batch_item_failures = []
     for message in messages:
-        event_type = message['messageAttributes']['type']['stringValue']
 
-        if event_type not in IMPLEMENTED_ENS_TYPES:
-            logger.warning(f"Skipping unsupported IAP ENS type: {event_type}")
-            continue
+        try:
+            event_type = message['messageAttributes']['type']['stringValue']
 
-        event_action = message['messageAttributes']['action']['stringValue']
-        message_body = libjson.loads(message['body'])
+            if event_type not in IMPLEMENTED_ENS_TYPES:
+                logger.warning(f"Skipping unsupported IAP ENS type: {event_type}")
+                continue
 
-        if event_type == ENSEventType.BSSH_RUNS.value:
-            handle_bssh_run_event(message, event_action, event_type, context)
+            event_action = message['messageAttributes']['action']['stringValue']
+            message_body = libjson.loads(message['body'])
 
-        if event_type == ENSEventType.WES_RUNS.value:
-            handle_wes_runs_event(message_body, context)
+            if event_type == ENSEventType.BSSH_RUNS.value:
+                handle_bssh_run_event(message, event_action, event_type, context)
 
-    _msg = f"IAP ENS event processing complete"
-    logger.info(_msg)
-    return _msg
+            if event_type == ENSEventType.WES_RUNS.value:
+                handle_wes_runs_event(message_body, context)
+
+            results.append(message['messageId'])
+
+        except Exception as e:
+            logger.exception(str(e), exc_info=e, stack_info=True)
+
+            # SQS Implement partial batch responses - ReportBatchItemFailures
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
+            batch_item_failures.append({
+                'itemIdentifier': message['messageId']
+            })
+
+    return {
+        'results': results,
+        'batchItemFailures': batch_item_failures
+    }
 
 
 def handle_bssh_run_event(message, event_action, event_type, context):

--- a/data_processors/pipeline/lambdas/tests/test_sqs_batch_event.py
+++ b/data_processors/pipeline/lambdas/tests/test_sqs_batch_event.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 
 from mockito import when
 
@@ -129,7 +130,7 @@ _mock_batch_event = {
 _mock_sqs_event = {
     "Records": [
         {
-            "messageId": "aaaaAA0e-4b00-4a2e-a92e-bdaa98c3eeEE",
+            "messageId": str(uuid.uuid4()),
             "receiptHandle": "AQEBiFujdr<snip>96Y=",
             "body": json.dumps(_mock_batch_event),
             "attributes": {

--- a/data_processors/pipeline/lambdas/tests/test_sqs_iap_event.py
+++ b/data_processors/pipeline/lambdas/tests/test_sqs_iap_event.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 
 from django.utils.timezone import make_aware
@@ -186,6 +187,7 @@ def _sqs_wes_event_message(wfv_id, wfr_id, workflow_status: WorkflowStatus = Wor
                     "SenderId": "ACTGAGCTI2IGZA4XHGYYY:sender-sender",
                     "ApproximateFirstReceiveTimestamp": "1589509337535"
                 },
+                "messageId": str(uuid.uuid4()),
             }
         ]
     }
@@ -263,6 +265,7 @@ def _sqs_bssh_event_message():
                     "ApproximateFirstReceiveTimestamp": "1589509337535"
                 },
                 "eventSourceARN": "arn:aws:sqs:ap-southeast-2:843407916570:my-queue",
+                "messageId": str(uuid.uuid4()),
             }
         ]
     }
@@ -319,7 +322,8 @@ class SQSIAPEventUnitTests(PipelineUnitTestCase):
                 {
                     "eventSource": "aws:sqs",
                     "body": "does_not_matter",
-                    "messageAttributes": ens_sqs_message_attributes
+                    "messageAttributes": ens_sqs_message_attributes,
+                    "messageId": str(uuid.uuid4()),
                 }
             ]
         }


### PR DESCRIPTION
* If SQS handler is configured with `ReportBatchItemFailures` then it
  has to return in proper Lambda response format such as dict or list.
  Otherwise, it gets treated as Lambda failure and put into DLQ.

  Read the doc "Success and failure conditions" clause:
  https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting

* Related #632
