### PR TITLE
Disabled ReportBatchItemFailures response for SQS Standard queue

### DIFF
--- a/data_processors/pipeline/lambdas/sqs_batch_event.py
+++ b/data_processors/pipeline/lambdas/sqs_batch_event.py
@@ -73,6 +73,7 @@ def handler(event, context):
             results.append(message['messageId'])
 
         except Exception as e:
+            logger.error(f"Exception raise processing messageId {message['messageId']}")
             logger.exception(str(e), exc_info=e, stack_info=True)
 
             # SQS Implement partial batch responses - ReportBatchItemFailures
@@ -84,7 +85,7 @@ def handler(event, context):
 
     return {
         'results': results,
-        'batchItemFailures': batch_item_failures
+        # 'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/sqs_iap_event.py
+++ b/data_processors/pipeline/lambdas/sqs_iap_event.py
@@ -68,6 +68,7 @@ def handler(event, context):
             results.append(message['messageId'])
 
         except Exception as e:
+            logger.error(f"Exception raise processing messageId {message['messageId']}")
             logger.exception(str(e), exc_info=e, stack_info=True)
 
             # SQS Implement partial batch responses - ReportBatchItemFailures
@@ -79,7 +80,7 @@ def handler(event, context):
 
     return {
         'results': results,
-        'batchItemFailures': batch_item_failures
+        # 'batchItemFailures': batch_item_failures
     }
 
 


### PR DESCRIPTION
* It is observed that while ReportBatchItemFailures fit well
  in FIFO queue with control messaging condition, it is
  a bit counterproductive in Standard queue situation.
  We shall observe more and tune as it goes. Disable for now.
* Related #632 #634
