### PR TITLE
Improved workflow service layer running workflow lookup

### DIFF
--- a/data_portal/models/workflow.py
+++ b/data_portal/models/workflow.py
@@ -37,7 +37,8 @@ class WorkflowManager(PortalBaseManager):
         qs: QuerySet = self.filter(
             sequence_run=sequence_run,
             type_name__iexact=type_name.lower(),
-            end__isnull=True
+            end__isnull=True,
+            end_status__iexact=WorkflowStatus.RUNNING.value
         )
         return qs
 

--- a/data_processors/pipeline/services/workflow_srv.py
+++ b/data_processors/pipeline/services/workflow_srv.py
@@ -139,17 +139,23 @@ def get_workflows_by_wfr_ids(wfr_id_list: List[str]) -> List[Workflow]:
 
 
 @transaction.atomic
-def get_running_by_sequence_run(sequence_run: SequenceRun, workflow_type: WorkflowType):
+def get_running_by_sequence_run(sequence_run: SequenceRun, workflow_type: WorkflowType) -> List[Workflow]:
     """query for Workflows associated with this SequenceRun"""
+    workflows = list()
+
     qs: QuerySet = Workflow.objects.get_running_by_sequence_run(
         sequence_run=sequence_run,
         type_name=workflow_type.value.lower()
     )
-    return qs.all()
+
+    if qs.exists():
+        for w in qs.all():
+            workflows.append(w)
+    return workflows
 
 
 @transaction.atomic
-def get_succeeded_by_sequence_run(sequence_run: SequenceRun, workflow_type: WorkflowType):
+def get_succeeded_by_sequence_run(sequence_run: SequenceRun, workflow_type: WorkflowType) -> List[Workflow]:
     """query for Succeeded Workflows associated with this SequenceRun"""
     workflows = list()
 


### PR DESCRIPTION
* Reinforced business logic lookup condition on running workflows
  by sequencerun. The `end` time must be null and `end_status` must
  be `Running` to evaluate as ongoing workflow.
