### PR TITLE
Rollback SQS Standard queue event router handler behaviour

### DIFF
--- a/data_processors/pipeline/lambdas/sqs_iap_event.py
+++ b/data_processors/pipeline/lambdas/sqs_iap_event.py
@@ -46,41 +46,27 @@ def handler(event, context):
     messages = event['Records']
 
     results = []
-    batch_item_failures = []
     for message in messages:
 
-        try:
-            event_type = message['messageAttributes']['type']['stringValue']
+        event_type = message['messageAttributes']['type']['stringValue']
 
-            if event_type not in IMPLEMENTED_ENS_TYPES:
-                logger.warning(f"Skipping unsupported IAP ENS type: {event_type}")
-                continue
+        if event_type not in IMPLEMENTED_ENS_TYPES:
+            logger.warning(f"Skipping unsupported IAP ENS type: {event_type}")
+            continue
 
-            event_action = message['messageAttributes']['action']['stringValue']
-            message_body = libjson.loads(message['body'])
+        event_action = message['messageAttributes']['action']['stringValue']
+        message_body = libjson.loads(message['body'])
 
-            if event_type == ENSEventType.BSSH_RUNS.value:
-                handle_bssh_run_event(message, event_action, event_type, context)
+        if event_type == ENSEventType.BSSH_RUNS.value:
+            handle_bssh_run_event(message, event_action, event_type, context)
 
-            if event_type == ENSEventType.WES_RUNS.value:
-                handle_wes_runs_event(message_body, context)
+        if event_type == ENSEventType.WES_RUNS.value:
+            handle_wes_runs_event(message_body, context)
 
-            results.append(message['messageId'])
-
-        except Exception as e:
-            logger.error(f"Exception raise processing messageId {message['messageId']}")
-            logger.exception(str(e), exc_info=e, stack_info=True)
-
-            # SQS Implement partial batch responses - ReportBatchItemFailures
-            # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
-            # https://repost.aws/knowledge-center/lambda-sqs-report-batch-item-failures
-            batch_item_failures.append({
-                'itemIdentifier': message['messageId']
-            })
+        results.append(message['messageId'])
 
     return {
         'results': results,
-        # 'batchItemFailures': batch_item_failures
     }
 
 

--- a/data_processors/pipeline/lambdas/tests/test_sqs_batch_event.py
+++ b/data_processors/pipeline/lambdas/tests/test_sqs_batch_event.py
@@ -163,7 +163,9 @@ class SQSBatchEventUnitTests(PipelineUnitTestCase):
 
         when(orchestrator).next_step(...).thenReturn({})  # do not advance to next step yet
 
-        _ = sqs_batch_event.handler(event=_mock_sqs_event, context=None)
+        resp = sqs_batch_event.handler(event=_mock_sqs_event, context=None)
+        self.assertIsNotNone(resp)
+        self.assertEqual(len(resp['results']), 1)  # assert that it should have processed 1 event message
 
         stub_workflow = Workflow.objects.get(portal_run_id=TestConstant.portal_run_id_oncoanalyser.value)
 

--- a/data_processors/pipeline/lambdas/tests/test_sqs_iap_event.py
+++ b/data_processors/pipeline/lambdas/tests/test_sqs_iap_event.py
@@ -328,8 +328,9 @@ class SQSIAPEventUnitTests(PipelineUnitTestCase):
             ]
         }
 
-        result = sqs_iap_event.handler(sqs_event_message, None)
-        self.assertIsNotNone(result)
+        resp = sqs_iap_event.handler(sqs_event_message, None)
+        self.assertIsNotNone(resp)
+        self.assertEqual(len(resp['results']), 0)  # since we skip event, assert that results is empty
 
     def test_sequence_run_event(self):
         """

--- a/serverless.yml
+++ b/serverless.yml
@@ -146,7 +146,6 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/s3_event_sqs_arn}
-          functionResponseType: ReportBatchItemFailures
     timeout: 120
     reservedConcurrency: 20
     # Uncomment to enable xray on this lambda
@@ -161,7 +160,6 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/ica_gds_event_sqs_arn}
-          functionResponseType: ReportBatchItemFailures
     timeout: 120
     reservedConcurrency: 20
 
@@ -172,7 +170,6 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/batch_event_sqs_arn}
-          functionResponseType: ReportBatchItemFailures
     timeout: 120
 
   sqs_iap_event_processor:
@@ -182,7 +179,6 @@ functions:
     events:
       - sqs:
           arn: ${ssm:/data_portal/backend/iap_ens_event_sqs_arn}
-          functionResponseType: ReportBatchItemFailures
     timeout: 120
 
   # SQS Implement partial batch responses - ReportBatchItemFailures


### PR DESCRIPTION
* For Standard queue, we would not need to leverage `ReportBatchItemFailures`
  as exception failure error handling is covered by DLQ. Furthermore,
  Standard queue are processed in high-throughput manner, i.e. no particular
  batching control mechanism necessary. Unordered and duplicates are all fine.
  Underlie application and database will take care of it.
* Process simple and fast. If error, keep messages in DLQ. Rolling back to
  this previous behaviour.
* The `ReportBatchItemFailures` is still desirable in all that of FIFO queues.
