### PR TITLE
Improved TSO ctDNA Lambda handler

### DIFF
--- a/data_processors/pipeline/lambdas/dragen_tso_ctdna.py
+++ b/data_processors/pipeline/lambdas/dragen_tso_ctdna.py
@@ -94,7 +94,6 @@ def handler(event, context) -> dict:
                 }
             }]
         },
-        ,
         "samplesheet": {
           "class": "File",
           "location": "gds://path/to/samplesheet"
@@ -107,8 +106,8 @@ def handler(event, context) -> dict:
           "class": "File",
           "location": "path/to/dir/RunParameters.xml"
         },
-        "seq_run_id": "sequence run id",
-        "seq_name": "sequence run name",
+        "seq_run_id": "BSSH run id",
+        "seq_name": "instrument_run_id",
         "batch_run_id": "batch run id",
         "library_id": "library id",
     }
@@ -121,8 +120,8 @@ def handler(event, context) -> dict:
     logger.info(f"Start processing {WorkflowType.DRAGEN_TSO_CTDNA.value} event")
     logger.info(libjson.dumps(event))
 
-    seq_run_id = event.get('seq_run_id', None)
-    seq_name = event.get('seq_name', None)
+    seq_run_id = event['seq_run_id']
+    seq_name = event['seq_name']
     batch_run_id = event.get('batch_run_id', None)
     library_id = event['library_id']
 
@@ -174,7 +173,7 @@ def handler(event, context) -> dict:
     )
 
     # establish link between Workflow and LibraryRun
-    _ = libraryrun_srv.link_library_runs_with_workflow(library_id, workflow)
+    _ = libraryrun_srv.link_library_runs_with_x_seq_workflow([library_id], workflow)
 
     # notification shall trigger upon wes.run event created action in workflow_update lambda
 

--- a/data_processors/pipeline/lambdas/star_alignment.py
+++ b/data_processors/pipeline/lambdas/star_alignment.py
@@ -94,10 +94,6 @@ def handler(event, context) -> dict:
     subject_id = event['subject_id']
     fastq_fwd = event['fastq_fwd']
     fastq_rev = event['fastq_rev']
-    assert library_id is not None
-    assert sample_id is not None
-    assert fastq_fwd is not None
-    assert fastq_rev is not None
 
     # see star alignment payload for preparing job JSON structure
     # https://github.com/umccr/nextflow-stack/pull/29

--- a/data_processors/pipeline/orchestration/tests/test_dragen_wgs_qc_step.py
+++ b/data_processors/pipeline/orchestration/tests/test_dragen_wgs_qc_step.py
@@ -8,6 +8,7 @@ from libica.openapi import libwes
 from libumccr.aws import libssm
 from mockito import when, spy2
 
+from data_portal.fields import IdHelper
 from data_portal.models.batch import Batch
 from data_portal.models.batchrun import BatchRun
 from data_portal.models.labmetadata import LabMetadata, LabMetadataPhenotype, LabMetadataType, LabMetadataWorkflow
@@ -174,8 +175,9 @@ class DragenWgsQcStepIntegrationTests(PipelineIntegrationTestCase):
         # ica workflows runs list
         # ica workflows runs get wfr.<ID>
 
-        bcl_convert_wfr_id = "wfr.18210c790f30452992c5fd723521f014"  # from PROD
-        total_jobs_to_eval = 12
+        # https://umccr.slack.com/archives/C8CG6K76W/p1701104259275569
+        bcl_convert_wfr_id = "wfr.dfc4cf0e0e114a06a3fa526e5bc8e972"  # from PROD
+        total_jobs_to_eval = 31
 
         # --- we need to rewind & replay pipeline state in the test db (like cassette tape, ya know!)
 
@@ -184,7 +186,7 @@ class DragenWgsQcStepIntegrationTests(PipelineIntegrationTestCase):
         # - populate LabMetadata tables in test db
         from data_processors.lims.lambdas import labmetadata
         labmetadata.scheduled_update_handler({
-            'sheets': ["2020", "2021"],
+            'sheets': ["2023"],
             'truncate': False
         }, None)
         logger.info(f"Lab metadata count: {LabMetadata.objects.count()}")
@@ -311,6 +313,7 @@ class DragenWgsQcStepIntegrationTests(PipelineIntegrationTestCase):
                 library_id, wfr_id = run_pair
                 wfr = wes.get_run(wfr_id=wfr_id)
                 wfl = Workflow.objects.create(
+                    portal_run_id=IdHelper.generate_portal_run_id(),
                     wfr_name=wfr.name,
                     type_name=WorkflowType.DRAGEN_TSO_CTDNA.value,
                     wfr_id=wfr.id,
@@ -324,7 +327,7 @@ class DragenWgsQcStepIntegrationTests(PipelineIntegrationTestCase):
                     sequence_run=sqr,
                     batch_run=init_batch_run,
                 )
-                libraryrun_srv.link_library_runs_with_workflow(library_id=library_id, workflow=wfl)
+                libraryrun_srv.link_library_runs_with_x_seq_workflow(library_id_list=[library_id], workflow=wfl)
 
         # first --
         # - we need metadata!
@@ -399,7 +402,7 @@ class DragenWgsQcStepIntegrationTests(PipelineIntegrationTestCase):
         # ica workflows runs get wfr.<ID>
 
         bcl_convert_wfr_id = "wfr.99e54af4fd694e49846f76d7a6a7035c"  # from DEV
-        total_jobs_to_eval = 38
+        total_jobs_to_eval = 35
 
         # --- we need to rewind & replay pipeline state in the test db (like cassette tape, ya know!)
 

--- a/data_processors/pipeline/services/libraryrun_srv.py
+++ b/data_processors/pipeline/services/libraryrun_srv.py
@@ -191,34 +191,6 @@ def link_library_run_with_workflow(library_id: str, lane: int, workflow: Workflo
 
 
 @transaction.atomic
-def link_library_runs_with_workflow(library_id: str, workflow: Workflow):
-    """
-    typically library_id is in its _pure_form_ such as rglb from FastqListRow i.e. no suffixes
-    workflow is still sequence-aware
-    """
-    seq_name = workflow.sequence_run.instrument_run_id
-    seq_run_id = workflow.sequence_run.run_id
-
-    rglb = liborca.strip_topup_rerun_from_library_id(library_id)
-
-    library_run_list: List[LibraryRun] = get_library_runs(
-        library_id=rglb,
-        instrument_run_id=seq_name,
-        run_id=seq_run_id,
-    )
-
-    for lib_run in library_run_list:
-        lib_run.workflows.add(workflow)
-        lib_run.save()
-
-    if library_run_list:
-        return library_run_list
-    else:
-        logger.warning(f"No LibraryRun records found for {rglb}, {seq_name}")
-        return None
-
-
-@transaction.atomic
 def link_library_runs_with_x_seq_workflow(library_id_list: List[str], workflow: Workflow):
     """
     typically library_id is in its _pure_form_ such as rglb from FastqListRow i.e. no suffixes

--- a/docs/pipeline/automation/tso_ctdna.md
+++ b/docs/pipeline/automation/tso_ctdna.md
@@ -14,7 +14,7 @@ _ADVANCED_
 _Step 1)_
 - To prepare event payload JSON as required in [Lambda payload schema](https://github.com/umccr/data-portal-apis/blob/dev/data_processors/pipeline/lambdas/dragen_tso_ctdna.py#L75-L114)
   - _Attached [tso_ctdna_payload.json](tso_ctdna_payload.json) here for convenience_
-- The attributes `seq_run_id`, `seq_name`, `batch_run_id` are optional.
+- The `batch_run_id` attribute is optional.
 
 
 _Step 2)_

--- a/docs/pipeline/automation/tso_ctdna_payload.json
+++ b/docs/pipeline/automation/tso_ctdna_payload.json
@@ -47,5 +47,7 @@
     "class": "File",
     "location": "gds://production/raw_data/Runs/211118_A01052_0064_BH372GDMXY_r.np5GFi6Nm0yByqui2vvLaA/RunParameters.xml"
   },
-  "library_id": "L2101400"
+  "library_id": "L2101400",
+  "seq_run_id": "r.np5GFi6Nm0yByqui2vvLaA",
+  "seq_name": "211118_A01052_0064_BH372GDMXY"
 }


### PR DESCRIPTION
* Enforced BSSH Run ID and Instrument Run ID requirement as Lambda payload contract
* Deprecated singular linkage service method between LibraryRun <> Workflow
  i.e. `libraryrun_srv.link_library_runs_with_workflow(library_id: str, workflow: Workflow)`
* Refactored to use SequenceRun cross over method for linkage `link_library_runs_with_x_seq_workflow(...)`
* Adjusted and improved affected integration test cases
* Removed redundant assertions from star_alignment handler
