### PR TITLE
Fix: Running local docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ version: '3.1'
 services:
 
   db:
-    image: public.ecr.aws/docker/library/mysql:8
+    image: public.ecr.aws/docker/library/mysql:8.4
     container_name: portal_db
-    command: |
-      --default-authentication-plugin=mysql_native_password
-      --max_allowed_packet=1G
-      --net-read-timeout=90
-      --net-write-timeout=180
+    command:
+      - '--mysql-native-password=ON'
+      - '--max_allowed_packet=1G'
+      - '--net-read-timeout=90'
+      - '--net-write-timeout=180'
     restart: always
     ports:
       - "3306:3306"


### PR DESCRIPTION
When running locally, the `public.ecr.aws/docker/library/mysql:8` is pulling the latest image and the `default-authentication-plugin` flag is now deprecated (`default-authentication-plugin=mysql_native_password: not found`). So updating the newer flag and pinning the image to a specific version.

Ref:
- https://dnsmichi.at/2024/05/11/docker-compose-ghost-msql-8-4-msql-native-password-startup-errors-mitigation-solution/
- https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html