### PR TITLE
Added support for EventBridge S3 event processing

### DIFF
--- a/data_processors/s3/services.py
+++ b/data_processors/s3/services.py
@@ -58,7 +58,13 @@ def _sync_s3_event_record_created(record: S3EventRecord) -> Tuple[int, int]:
     bucket_name = record.s3_bucket_name
     key = record.s3_object_meta['key']
     size = record.s3_object_meta['size']
-    e_tag = record.s3_object_meta['eTag']
+
+    if 'eTag' in record.s3_object_meta:
+        e_tag = record.s3_object_meta['eTag']  # S3 Event Notification convention
+    elif 'etag' in record.s3_object_meta:
+        e_tag = record.s3_object_meta['etag']  # EventBridge convention
+    else:
+        e_tag = None
 
     tag_s3_object(bucket_name, key, "bam")
 


### PR DESCRIPTION
* Updated S3 event parser to handle ObjectCreated and ObjectDeleted come
  through EventBridge event envelope.
* Added relevant unit test cases as guard-rail around parser logic
* Part of story #684
* Related https://github.com/umccr/infrastructure/issues/434
