### PR TITLE
add content disposition header for s3 presign api

### DIFF
--- a/data_portal/viewsets/s3object.py
+++ b/data_portal/viewsets/s3object.py
@@ -42,7 +42,8 @@ class S3ObjectViewSet(ReadOnlyModelViewSet):
     @action(detail=True)
     def presign(self, request, pk=None):
         obj: S3Object = self.get_object()
-        return _presign_response(obj.bucket, obj.key)
+        content_disposition = request.headers.get('Content-Disposition', 'attachment') 
+        return _presign_response(obj.bucket, obj.key, content_disposition)
 
     @action(detail=True)
     def status(self, request, pk=None):

--- a/data_portal/viewsets/utils.py
+++ b/data_portal/viewsets/utils.py
@@ -12,8 +12,11 @@ def _error_response(message, status_code=400, err=None) -> Response:
     )
 
 
-def _presign_response(bucket, key) -> Response:
-    response = libs3.presign_s3_file(bucket, key)
+def _presign_response(bucket, key, content_disposition) -> Response:
+    
+    #  need modify libumccr to pass content_disposition to libs3.presign_s3_file
+    response = libs3.presign_s3_file(bucket, key, content_disposition)
+    
     if response[0]:
         return Response({'signed_url': response[1]})
     else:

--- a/data_portal/viewsets/utils.py
+++ b/data_portal/viewsets/utils.py
@@ -13,10 +13,7 @@ def _error_response(message, status_code=400, err=None) -> Response:
 
 
 def _presign_response(bucket, key, content_disposition) -> Response:
-    
-    #  need modify libumccr to pass content_disposition to libs3.presign_s3_file
     response = libs3.presign_s3_file(bucket, key, content_disposition)
-    
     if response[0]:
         return Response({'signed_url': response[1]})
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ python-dateutil==2.9.0.post0
 google-auth==2.30.0
 Werkzeug==3.0.3
 libica==2.4.0
-libumccr==0.3.0
+libumccr==0.4.0rc4
 gspread==5.12.4
 gspread-pandas==3.3.0
 sample-sheet==0.13.0


### PR DESCRIPTION
Fix:

add 'Content-Disposition' header in 'preview' s3 presignurl api, and change default presignurl behaviour to download as attachment.

These may need couple modification of `libumccr.aws.libs3.presign_s3_file` to be able add 'content_disposition' params for s3 presignurl call.

PR of libumccr: https://github.com/umccr/libumccr/pull/28

Link: https://github.com/umccr/data-portal-client/issues/342

Refer: about boto3 presign url pass disposition header: https://github.com/boto/boto3/issues/356#issuecomment-155919331
https://github.com/boto/boto3/issues/610#issuecomment-443878760
