### PR TITLE
Support use of MarkDups BAMs in oncoanalyser_wgts_existing_both_step

### DIFF
--- a/data_processors/pipeline/orchestration/oncoanalyser_wgts_existing_both_step.py
+++ b/data_processors/pipeline/orchestration/oncoanalyser_wgts_existing_both_step.py
@@ -225,10 +225,6 @@ def get_existing_wgs_markdups_bam(existing_wgs_dir: str, sample_id: str):
 
     filtered_list = list(filter(lambda x: str(x).endswith(".bam"), results))
 
-    results_all = s3object_srv.get_s3_files_for_path_tokens(path_tokens=[
-        existing_wgs_dir_prefix,
-    ])
-
     if len(filtered_list) != 1:
         message_component = "No MarkDups BAM" if len(filtered_list) == 0 else "Multiple MarkDups BAMs"
         raise ValueError(f"{message_component} found in existing WGS output: {existing_wgs_dir}")

--- a/data_processors/pipeline/orchestration/oncoanalyser_wgts_existing_both_step.py
+++ b/data_processors/pipeline/orchestration/oncoanalyser_wgts_existing_both_step.py
@@ -7,6 +7,7 @@ See orchestration package __init__.py doc string.
 import json
 import logging
 from typing import Optional
+from urllib.parse import urlparse
 
 from libumccr.aws import libssm, libsqs
 
@@ -216,12 +217,17 @@ def get_existing_wgs_markdups_bam(existing_wgs_dir: str, sample_id: str):
     :raises ValueError: if exactly one MarkDups BAM isn't found
     """
 
+    existing_wgs_dir_prefix = urlparse(existing_wgs_dir).path.lstrip('/')
     results = s3object_srv.get_s3_files_for_path_tokens(path_tokens=[
-        existing_wgs_dir,
+        existing_wgs_dir_prefix,
         f"alignments/dna/{sample_id}.markdups.bam",
     ])
 
     filtered_list = list(filter(lambda x: str(x).endswith(".bam"), results))
+
+    results_all = s3object_srv.get_s3_files_for_path_tokens(path_tokens=[
+        existing_wgs_dir_prefix,
+    ])
 
     if len(filtered_list) != 1:
         message_component = "No MarkDups BAM" if len(filtered_list) == 0 else "Multiple MarkDups BAMs"


### PR DESCRIPTION
### Background

- this change accommodates the new MarkDups stage in oncoanalyser dev [20240711; 1.0.0 release candidate]
- the MarkDups stage takes the input DRAGEN WGS BAMs and generates processed BAMs that are used for analysis
- it is therefore expected that when running with existing inputs the MarkDups WGS BAMs are provided to oncoanalyser

### Changes

A high-level summary of changes is provided in the below figure (shown in red).

![image](https://github.com/umccr/data-portal-apis/assets/463926/8d3e2213-9d35-4bac-8d0b-6b534cc8e388)

_Detailed changes_

- oncoanalyser_wgts_existing_both_step orchestrator now discovers MarkDups WGS BAMs from existing WGS directory
- discovered MarkDups WGS BAMs replace DRAGEN WGS BAMs as payload input to the corresponding Lambda function
- an error will be raised when no MarkDups WGS BAMs are found
  -  this intentionally requires users to run oncoanalyser WGS to generate the appropriate MarkDups WGS BAMs
  - and doing so will have oncoanalyser WGTS (existing both) automatically trigger assuming WTS outputs are present
  - this gives backwards compatibility and guards against errors caused where patients have an incomplete complement of WGS/WTS data then receive their respective WGS or WTS sample following this change
- new tests have been implemented for the new functionality

### Other notes

- some consider needs to be made so that MarkDups BAMs are subject to our internal lifecycle policies for this filetype