### PR TITLE
add filename in disposition header

### DIFF
--- a/data_portal/viewsets/s3object.py
+++ b/data_portal/viewsets/s3object.py
@@ -44,7 +44,7 @@ class S3ObjectViewSet(ReadOnlyModelViewSet):
     @action(detail=True)
     def presign(self, request, pk=None):
         obj: S3Object = self.get_object()
-        content_disposition = request.headers.get('Content-Disposition', 'attachment') 
+        content_disposition = request.headers.get('Content-Disposition', 'attachment') + '; filename=' + obj.key.split('/')[-1]
         return _presign_response(obj.bucket, obj.key, content_disposition)
 
     @action(detail=True)


### PR DESCRIPTION
Fix for download file name renamed issue.

Fix: extract filename from object key path, and add filename in disposition header to define download file name. 

Example: https://github.com/boto/boto3/issues/356#issuecomment-155919331

Link: https://github.com/umccr/data-portal-client/issues/342